### PR TITLE
Fix SQLite schema for project description

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,7 @@ datasource db {
 model Project {
   id          Int      @id @default(autoincrement())
   name        String
-  description String?  @db.Text
+  description String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 }


### PR DESCRIPTION
## Summary
- remove the unsupported `@db.Text` native type annotation from the Project.description field so Prisma can compile against SQLite

## Testing
- yarn prisma generate *(fails: Prisma engine checksum download returned 403 Forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1f33351c832cbdf32d67f7b74812