### PR TITLE
Fix NextAuth session callback when user payload is missing

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -30,7 +30,11 @@ export const authOptions: NextAuthOptions = {
   secret: getRequiredEnv("NEXTAUTH_SECRET"),
   callbacks: {
     session: async ({ session, user }) => {
-      if (session.user) {
+      if (!session.user) {
+        return session;
+      }
+
+      if (user) {
         session.user.id = user.id;
         session.user.name = user.name;
         session.user.email = user.email;


### PR DESCRIPTION
## Summary
- prevent the NextAuth session callback from crashing when it runs without a user payload

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68cd46c1d0b4832c868f3a61ce2867ef