### PR TITLE
Refine design doc task plan

### DIFF
--- a/spec/designdoc.xml
+++ b/spec/designdoc.xml
@@ -106,90 +106,76 @@
 
   <section title="Декомпозиция задач">
     <task id="1" name="Инициализация проекта">
-      <description>Создать репозиторий, настроить Next.js 14/15, TypeScript, ESLint, Prettier, Husky. Подключить Material UI. Настроить Prisma ORM, подключить PostgreSQL, выполнить первую миграцию. Подготовить базовый CI/CD pipeline (GitHub Actions, Vercel).</description>
+      <description>Создать репозиторий, настроить Next.js 14/15, TypeScript, ESLint, Prettier, Husky. Подключить Material UI. Настроить Prisma ORM, подключить PostgreSQL, определить процессы prisma migrate dev/deploy с правилами именования и выполнить первую миграцию. Подготовить базовый CI/CD pipeline (GitHub Actions, Vercel).</description>
       <contracts>Нет</contracts>
       <dependencies>Нет</dependencies>
       <blockers>Блокирует все последующие задачи.</blockers>
     </task>
 
     <task id="2" name="Аутентификация (AuthService)">
-      <description>Настроить Google OAuth через NextAuth.js. Определить модель User в Prisma. Реализовать вход, выход, получение текущей сессии. Хранить в БД email, имя, фото пользователя.</description>
+      <description>Настроить Google OAuth через NextAuth.js. Определить модель User в Prisma. Реализовать вход, выход, получение текущей сессии. Хранить в БД email, имя, фото пользователя. Создать страницу /login на Material UI с кнопкой входа через Google, обработкой состояний загрузки и ошибок.</description>
       <contracts>login(), logout(), getCurrentUser()</contracts>
       <dependencies ref="task-1">Инициализация проекта</dependencies>
       <blockers>Блокирует управление workspace и участниками.</blockers>
     </task>
 
-    <task id="3" name="Инфраструктура миграций Prisma">
-      <description>Настроить процессы prisma migrate dev/deploy, договориться о правилах именования моделей и миграций. Подготовить базовую (пустую) миграцию и документацию, чтобы остальные задачи могли добавлять свои сущности по мере необходимости.</description>
-      <contracts>Документация по процессу миграций Prisma, базовая миграция</contracts>
-      <dependencies ref="task-1">Инициализация проекта</dependencies>
-      <blockers>Обеспечивает возможность расширять схему БД в последующих задачах.</blockers>
-    </task>
-
-    <task id="4" name="Управление рабочими областями (WorkspaceService)">
-      <description>CRUD для рабочих областей, связь с пользователями. Управление списком workspace у пользователя. Добавить в Prisma модель Workspace (id, name, ownerId, slug, timestamps) и выполнить миграцию.</description>
+    <task id="3" name="Управление рабочими областями (WorkspaceService)">
+      <description>CRUD для рабочих областей, связь с пользователями. Управление списком workspace у пользователя. Добавить в Prisma модель Workspace (id, name, ownerId, slug, timestamps) и выполнить миграцию. Реализовать страницу /workspaces с таблицей или карточками рабочих областей, модальным окном создания workspace и интеграцией Server Actions для создания, обновления и удаления.</description>
       <contracts>createWorkspace(), getWorkspace(), updateWorkspace(), deleteWorkspace()</contracts>
-      <dependencies ref="task-2 task-3">Аутентификация, инфраструктура миграций</dependencies>
+      <dependencies ref="task-1 task-2">Инициализация проекта, Аутентификация</dependencies>
       <blockers>Открывает управление участниками, комнатами и шаблонами.</blockers>
     </task>
 
-    <task id="5" name="Управление участниками и ролями (MemberService)">
-      <description>Приглашение пользователей по e-mail. Генерация токена приглашения. Сохранение в БД. Изменение роли, удаление участника. Передача прав при удалении администратора. Добавить модели Member и InvitationToken (при необходимости) в Prisma, настроить связи User ↔ Workspace и миграцию.</description>
+    <task id="4" name="Управление участниками и ролями (MemberService)">
+      <description>Приглашение пользователей по e-mail. Генерация токена приглашения. Сохранение в БД. Изменение роли, удаление участника. Передача прав при удалении администратора. Добавить модели Member и InvitationToken (при необходимости) в Prisma, настроить связи User ↔ Workspace и миграцию. Реализовать UI управления участниками на странице workspace/[id]: список участников, формы приглашения и модальные окна для изменения ролей и удаления с подключением Server Actions.</description>
       <contracts>inviteMember(), acceptInvitation(), changeRole(), removeMember()</contracts>
-      <dependencies ref="task-2 task-3 task-4">Auth, инфраструктура миграций, Workspace</dependencies>
+      <dependencies ref="task-2 task-3">Auth, Workspace</dependencies>
       <blockers>Открывает создание комнат.</blockers>
     </task>
 
-    <task id="6" name="Управление комнатами (RoomService)">
-      <description>Создание комнат, привязка к workspace. Генерация slug/ссылки. Настройки: язык по умолчанию, права анонимных участников. Архивация/удаление. UI списка комнат. Добавить модель Room в Prisma (workspaceId, slug, настройки) и миграцию.</description>
+    <task id="5" name="Управление комнатами (RoomService)">
+      <description>Создание комнат, привязка к workspace. Генерация slug/ссылки. Настройки: язык по умолчанию, права анонимных участников. Архивация/удаление. Добавить модель Room в Prisma (workspaceId, slug, настройки) и миграцию. Реализовать список комнат на странице workspace/[id], модальное окно создания комнаты и страницу room/[slug] с настройками доступа и состояниями комнаты.</description>
       <contracts>createRoom(), getRoom(), updateRoom(), closeRoom()</contracts>
-      <dependencies ref="task-4 task-5 task-3">Workspace, Members, инфраструктура миграций</dependencies>
+      <dependencies ref="task-3 task-4">Workspace, Members</dependencies>
       <blockers>Открывает коллаборацию и запуск кода.</blockers>
     </task>
 
-    <task id="7" name="Управление шаблонами (TemplateService)">
-      <description>CRUD шаблонов. Импорт шаблона в комнату. Импорт в новую комнату при создании. Добавить модель Template в Prisma с привязкой к workspace и выполнить миграцию.</description>
+    <task id="6" name="Управление шаблонами (TemplateService)">
+      <description>CRUD шаблонов. Импорт шаблона в комнату. Импорт в новую комнату при создании. Добавить модель Template в Prisma с привязкой к workspace и выполнить миграцию. Реализовать библиотеку шаблонов в UI страницы workspace/[id] с модальными окнами создания/редактирования и возможностью импортировать шаблон в комнату через Server Actions.</description>
       <contracts>createTemplate(), updateTemplate(), deleteTemplate(), importTemplateToRoom()</contracts>
-      <dependencies ref="task-3 task-4">Инфраструктура миграций, Workspace</dependencies>
-      <blockers>Можно делать параллельно с task-6. Импорт требует готовности RoomService.</blockers>
+      <dependencies ref="task-3">Workspace</dependencies>
+      <blockers>Можно делать параллельно с task-5. Импорт требует готовности RoomService.</blockers>
     </task>
 
-    <task id="8" name="Совместное редактирование (CollaborationService)">
-      <description>Настроить y-websocket сервер. Хранить y-document для каждой комнаты. Подключение через y-monaco. Awareness (курсоры, имена). Настроить права для viewer/анонимов. Модерация: блокировка редактирования.</description>
+    <task id="7" name="Совместное редактирование (CollaborationService)">
+      <description>Настроить y-websocket сервер. Хранить y-document для каждой комнаты. Подключение через y-monaco. Awareness (курсоры, имена). Настроить права для viewer/анонимов. Модерация: блокировка редактирования. Интегрировать Monaco Editor, список участников и чат в UI страницы room/[slug] с отображением состояний подключения.</description>
       <contracts>connectToRoom(roomSlug, userToken)</contracts>
-      <dependencies ref="task-6">RoomService</dependencies>
+      <dependencies ref="task-5">RoomService</dependencies>
       <blockers>После реализации подключается к редактору кода.</blockers>
     </task>
 
-    <task id="9" name="Запуск кода в браузере (ExecutionService)">
-      <description>Запуск JS/TS/React кода в iframe sandbox. Транспиляция через Babel/esbuild-wasm. Перенаправление console.log в окно вывода. Тайм-лимиты. Ограничение доступа. UI: кнопка «Запустить», окно вывода. Логирование каждого запуска.</description>
+    <task id="8" name="Запуск кода в браузере (ExecutionService)">
+      <description>Запуск JS/TS/React кода в iframe sandbox. Транспиляция через Babel/esbuild-wasm. Перенаправление console.log в окно вывода. Тайм-лимиты. Ограничение доступа. UI: кнопка «Запустить», окно вывода, отображение статуса выполнения рядом с редактором.</description>
       <contracts>runCodeInBrowser({language, code}) → {output, error, duration}</contracts>
-      <dependencies ref="task-6">RoomService</dependencies>
-      <blockers>Можно параллельно с task-8.</blockers>
+      <dependencies ref="task-5">RoomService</dependencies>
+      <blockers>Можно параллельно с task-7.</blockers>
     </task>
 
-    <task id="10" name="Логирование действий (LoggingService)">
-      <description>Принимать события из CollaborationService, RoomService, TemplateService, ExecutionService. Сохранять в LogEntry. API выборки логов. UI администратора с фильтрацией. Добавить модель LogEntry и связанные enum/тип данных в Prisma, выполнить миграцию.</description>
+    <task id="9" name="Логирование действий (LoggingService)">
+      <description>Принимать события из CollaborationService, RoomService, TemplateService, ExecutionService. Сохранять в LogEntry. API выборки логов. Реализовать UI администратора с фильтрацией логов на странице workspace/[id] или отдельной админ-странице. Добавить модель LogEntry и связанные enum/тип данных в Prisma, выполнить миграцию.</description>
       <contracts>logEvent(), getLogs()</contracts>
-      <dependencies ref="task-6 task-3">RoomService, инфраструктура миграций</dependencies>
-      <blockers>Можно параллельно с task-8 и task-9.</blockers>
+      <dependencies ref="task-5">RoomService</dependencies>
+      <blockers>Можно параллельно с task-7 и task-8.</blockers>
     </task>
 
-    <task id="11" name="Реализация UI">
-      <description>Next.js + MUI. Страницы: login, workspaces, workspace/[id], room/[slug]. Модальные окна: создание workspace, шаблоны, приглашения, настройки комнаты. Редактор Monaco, окно вывода, чат, список участников.</description>
-      <contracts>UI компоненты взаимодействуют с Server Actions.</contracts>
-      <dependencies ref="task-1">Инициализация</dependencies>
-      <blockers>Можно параллельно с серверными задачами.</blockers>
-    </task>
-
-    <task id="12" name="Система разрешений и middleware">
-      <description>Middleware Next.js для проверки сессий и ролей. Проверка настроек anonymousPermissions. Проверка прав в Server Actions.</description>
+    <task id="10" name="Система разрешений и middleware">
+      <description>Middleware Next.js для проверки сессий и ролей. Проверка настроек anonymousPermissions. Проверка прав в Server Actions и блокировка UI-элементов, недоступных текущему пользователю.</description>
       <contracts>hasRole(), checkRoomAccess(), withAuth()</contracts>
-      <dependencies ref="task-2 task-4">Auth, Workspace</dependencies>
+      <dependencies ref="task-2 task-3">Auth, Workspace</dependencies>
       <blockers>Должна быть до интеграции серверных методов.</blockers>
     </task>
 
-    <task id="13" name="Деплой и DevOps">
+    <task id="11" name="Деплой и DevOps">
       <description>Настроить окружения (dev/staging/prod). Vercel для продакшна. Переменные окружения (OAuth ключи, DB URL). CI/CD (GitHub Actions). Мониторинг WebSocket серверов.</description>
       <contracts>Docker, vercel.json, env файлы, init script БД</contracts>
       <dependencies ref="task-1">Инициализация</dependencies>


### PR DESCRIPTION
## Summary
- remove the standalone Prisma migration infrastructure task and fold migration process details into project initialization
- renumber the remaining feature tasks and update their dependency references
- distribute the UI implementation work across the relevant feature tasks for iterative delivery

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68cdd24185b8832ca4c0ec694b4c65c9