### PR TITLE
Centralize route definitions in shared ROUTES map

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,8 @@ import {
 } from "@mui/material";
 import Link from "next/link";
 
+import { ROUTES } from "@/routes";
+
 const featureHighlights = [
   {
     title: "Next.js 15",
@@ -32,7 +34,7 @@ const featureHighlights = [
 ];
 
 export default function HomePage() {
-  const loginHref = `/api/auth/signin?callbackUrl=${encodeURIComponent("/workspaces")}`;
+  const loginHref = ROUTES.signin({ callbackUrl: ROUTES.workspaces });
 
   return (
     <Container component="main" maxWidth="lg" sx={{ py: { xs: 6, md: 10 } }}>
@@ -51,7 +53,7 @@ export default function HomePage() {
             <Button component={Link} href={loginHref} variant="contained" size="large">
               Войти
             </Button>
-            <Button component={Link} href="/api/hello" variant="contained" size="large">
+            <Button component={Link} href={ROUTES.apiHello} variant="contained" size="large">
               Explore API route
             </Button>
             <Button

--- a/src/app/workspaces/actions.ts
+++ b/src/app/workspaces/actions.ts
@@ -10,6 +10,8 @@ import {
   updateWorkspace,
 } from "@/lib/services/workspace";
 
+import { ROUTES } from "@/routes";
+
 export type WorkspaceActionState = {
   status: "idle" | "success" | "error";
   message?: string;
@@ -58,7 +60,7 @@ export async function createWorkspaceAction(
 
   try {
     await createWorkspace(user.id, { name, slug });
-    revalidatePath("/workspaces");
+    revalidatePath(ROUTES.workspaces);
 
     return {
       status: "success",
@@ -100,7 +102,7 @@ export async function updateWorkspaceAction(
 
   try {
     await updateWorkspace(user.id, workspaceId, { name, slug });
-    revalidatePath("/workspaces");
+    revalidatePath(ROUTES.workspaces);
 
     return {
       status: "success",
@@ -130,7 +132,7 @@ export async function deleteWorkspaceAction(workspaceId: string): Promise<Worksp
 
   try {
     await deleteWorkspace(user.id, workspaceId);
-    revalidatePath("/workspaces");
+    revalidatePath(ROUTES.workspaces);
 
     return {
       status: "success",

--- a/src/app/workspaces/page.tsx
+++ b/src/app/workspaces/page.tsx
@@ -4,6 +4,8 @@ import { redirect } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth";
 import { listWorkspaces } from "@/lib/services/workspace";
 
+import { ROUTES } from "@/routes";
+
 import WorkspacesClient from "./workspaces-client";
 
 export const metadata: Metadata = {
@@ -15,7 +17,7 @@ export default async function WorkspacesPage() {
   const user = await getCurrentUser();
 
   if (!user) {
-    redirect(`/api/auth/signin?callbackUrl=${encodeURIComponent("/workspaces")}`);
+    redirect(ROUTES.signin({ callbackUrl: ROUTES.workspaces }));
   }
 
   const workspaces = await listWorkspaces(user.id);

--- a/src/app/workspaces/workspaces-client.tsx
+++ b/src/app/workspaces/workspaces-client.tsx
@@ -33,6 +33,8 @@ import { createWorkspaceAction, deleteWorkspaceAction, updateWorkspaceAction } f
 import { slugify, withSlugFallback } from "@/lib/utils/slugify";
 import { logout } from "@/lib/auth-client";
 
+import { ROUTES } from "@/routes";
+
 type SerializedWorkspace = {
   id: string;
   name: string;
@@ -358,7 +360,7 @@ export function WorkspacesClient({ workspaces, currentUser }: WorkspacesClientPr
 
   const handleLogout = () => {
     startLogout(async () => {
-      await logout({ callbackUrl: "/" });
+      await logout({ callbackUrl: ROUTES.home });
     });
   };
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,12 @@
+export type SignInRouteParams = {
+  callbackUrl: string;
+};
+
+export const ROUTES = {
+  home: "/",
+  workspaces: "/workspaces",
+  apiHello: "/api/hello",
+  signin({ callbackUrl }: SignInRouteParams) {
+    return `/api/auth/signin?callbackUrl=${encodeURIComponent(callbackUrl)}`;
+  },
+} as const;


### PR DESCRIPTION
## Summary
- add a shared `ROUTES` object describing static and dynamic application URLs
- update workspace actions, pages, and logout logic to consume the centralized route helpers

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68d070248f8c832ca62d432e44443100