### PR TITLE
Fix template server action exports

### DIFF
--- a/src/app/workspaces/[workspaceId]/templates/actions.ts
+++ b/src/app/workspaces/[workspaceId]/templates/actions.ts
@@ -6,20 +6,12 @@ import { TemplateLanguage } from "@prisma/client";
 import { getCurrentUser } from "@/lib/auth";
 import {
   TemplateError,
-  type TemplateField,
   createTemplate,
   updateTemplate,
   deleteTemplate,
 } from "@/lib/services/template";
+import type { TemplateActionState } from "./template-action-state";
 import { ROUTES } from "@/routes";
-
-export type TemplateActionState = {
-  status: "idle" | "success" | "error";
-  message?: string;
-  fieldErrors?: Partial<Record<TemplateField, string>>;
-};
-
-const idleState: TemplateActionState = { status: "idle" };
 
 function buildErrorState(error: unknown, fallbackMessage: string): TemplateActionState {
   if (error instanceof TemplateError) {
@@ -213,5 +205,3 @@ export async function deleteTemplateAction(
     return buildErrorState(error, "Не удалось удалить шаблон.");
   }
 }
-
-export { idleState as templateActionIdleState };

--- a/src/app/workspaces/[workspaceId]/templates/template-action-state.ts
+++ b/src/app/workspaces/[workspaceId]/templates/template-action-state.ts
@@ -1,0 +1,9 @@
+import type { TemplateField } from "@/lib/services/template";
+
+export type TemplateActionState = {
+  status: "idle" | "success" | "error";
+  message?: string;
+  fieldErrors?: Partial<Record<TemplateField, string>>;
+};
+
+export const templateActionIdleState: TemplateActionState = { status: "idle" };

--- a/src/app/workspaces/[workspaceId]/templates/template-delete-dialog.tsx
+++ b/src/app/workspaces/[workspaceId]/templates/template-delete-dialog.tsx
@@ -15,7 +15,8 @@ import {
 
 import type { SerializedTemplate } from "@/lib/services/template";
 
-import { deleteTemplateAction, templateActionIdleState } from "./actions";
+import { deleteTemplateAction } from "./actions";
+import { templateActionIdleState } from "./template-action-state";
 
 type TemplateDeleteDialogProps = {
   open: boolean;

--- a/src/app/workspaces/[workspaceId]/templates/template-form-dialog.tsx
+++ b/src/app/workspaces/[workspaceId]/templates/template-form-dialog.tsx
@@ -21,7 +21,8 @@ import {
 
 import type { SerializedTemplate } from "@/lib/services/template";
 
-import { createTemplateAction, templateActionIdleState, updateTemplateAction } from "./actions";
+import { createTemplateAction, updateTemplateAction } from "./actions";
+import { templateActionIdleState } from "./template-action-state";
 
 export type TemplateFormDialogMode = "create" | "edit";
 


### PR DESCRIPTION
## Summary
- move the shared template action state definition into a standalone module so the server action file only exports async functions
- update the template dialogs to import the idle state from the new module

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68d08a707de8832cbf94a99468763f6a