### PR TITLE
Improve workspace template management

### DIFF
--- a/src/app/workspaces/[workspaceId]/templates/template-form-dialog.tsx
+++ b/src/app/workspaces/[workspaceId]/templates/template-form-dialog.tsx
@@ -164,7 +164,6 @@ export default function TemplateFormDialog({
               name="content"
               value={content}
               onChange={(event) => setContent(event.target.value)}
-              required
               fullWidth
               multiline
               minRows={8}
@@ -172,7 +171,7 @@ export default function TemplateFormDialog({
               error={Boolean(state.fieldErrors?.content)}
               helperText={
                 state.fieldErrors?.content ??
-                "Вставьте фрагмент кода или текст, который хотите переиспользовать."
+                "Вставьте фрагмент кода или текст, который хотите переиспользовать (необязательно)."
               }
             />
           </Stack>

--- a/src/app/workspaces/[workspaceId]/templates/templates-client.tsx
+++ b/src/app/workspaces/[workspaceId]/templates/templates-client.tsx
@@ -93,8 +93,11 @@ export default function TemplatesClient({
   const [filterLanguage, setFilterLanguage] = useState<LanguageFilterValue>("ALL");
   const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [createDialogKey, setCreateDialogKey] = useState(0);
   const [editTarget, setEditTarget] = useState<SerializedTemplate | null>(null);
+  const [editDialogKey, setEditDialogKey] = useState(0);
   const [deleteTarget, setDeleteTarget] = useState<SerializedTemplate | null>(null);
+  const [deleteDialogKey, setDeleteDialogKey] = useState(0);
 
   const filteredTemplates = useMemo(() => {
     if (filterLanguage === "ALL") {
@@ -111,11 +114,11 @@ export default function TemplatesClient({
     }
 
     setSelectedTemplateId((current) => {
-      if (!current) {
-        return templates[0].id;
+      if (current && templates.some((template) => template.id === current)) {
+        return current;
       }
 
-      return templates.some((template) => template.id === current) ? current : templates[0].id;
+      return null;
     });
   }, [templates]);
 
@@ -130,7 +133,7 @@ export default function TemplatesClient({
         return current;
       }
 
-      return filteredTemplates[0]?.id ?? null;
+      return null;
     });
   }, [filteredTemplates]);
 
@@ -149,6 +152,25 @@ export default function TemplatesClient({
 
   const handleFeedback = (message: string, severity: "success" | "error" = "success") => {
     setFeedback({ message, severity });
+  };
+
+  const openCreateDialog = () => {
+    setIsCreateOpen(true);
+  };
+
+  const closeCreateDialog = () => {
+    setIsCreateOpen(false);
+    setCreateDialogKey((value) => value + 1);
+  };
+
+  const closeEditDialog = () => {
+    setEditTarget(null);
+    setEditDialogKey((value) => value + 1);
+  };
+
+  const closeDeleteDialog = () => {
+    setDeleteTarget(null);
+    setDeleteDialogKey((value) => value + 1);
   };
 
   return (
@@ -208,7 +230,7 @@ export default function TemplatesClient({
               </Box>
               <Stack direction="row" spacing={1}>
                 {canManage ? (
-                  <Button variant="contained" onClick={() => setIsCreateOpen(true)}>
+                  <Button variant="contained" onClick={openCreateDialog}>
                     Новый шаблон
                   </Button>
                 ) : null}
@@ -367,27 +389,30 @@ export default function TemplatesClient({
       </Stack>
 
       <TemplateFormDialog
+        key={`create-${createDialogKey}`}
         open={isCreateOpen}
         mode="create"
         workspaceId={workspace.id}
         languages={languageOptions}
-        onClose={() => setIsCreateOpen(false)}
+        onClose={closeCreateDialog}
         onSuccess={(message) => handleFeedback(message, "success")}
       />
       <TemplateFormDialog
+        key={`edit-${editDialogKey}-${editTarget?.id ?? "none"}`}
         open={Boolean(editTarget)}
         mode="edit"
         workspaceId={workspace.id}
         languages={languageOptions}
         template={editTarget}
-        onClose={() => setEditTarget(null)}
+        onClose={closeEditDialog}
         onSuccess={(message) => handleFeedback(message, "success")}
       />
       <TemplateDeleteDialog
+        key={`delete-${deleteDialogKey}-${deleteTarget?.id ?? "none"}`}
         open={Boolean(deleteTarget)}
         workspaceId={workspace.id}
         template={deleteTarget}
-        onClose={() => setDeleteTarget(null)}
+        onClose={closeDeleteDialog}
         onSuccess={(message) => handleFeedback(message, "success")}
       />
     </Container>

--- a/src/app/workspaces/workspaces-client.tsx
+++ b/src/app/workspaces/workspaces-client.tsx
@@ -507,6 +507,14 @@ export function WorkspacesClient({ workspaces, currentUser }: WorkspacesClientPr
                         <TableCell>{formatDate(workspace.createdAt)}</TableCell>
                         <TableCell align="right">
                           <Stack direction="row" spacing={1} justifyContent="flex-end">
+                            <Button
+                              size="small"
+                              variant="outlined"
+                              component={Link}
+                              href={ROUTES.workspaceTemplates(workspace.id)}
+                            >
+                              Шаблоны
+                            </Button>
                             {workspace.role === "ADMIN" ? (
                               <Button
                                 size="small"

--- a/src/lib/services/template.ts
+++ b/src/lib/services/template.ts
@@ -20,7 +20,6 @@ const NAME_MIN_LENGTH = 3;
 const NAME_MAX_LENGTH = 120;
 const DESCRIPTION_MAX_LENGTH = 500;
 const HIDDEN_DESCRIPTION_MAX_LENGTH = 1000;
-const CONTENT_MIN_LENGTH = 1;
 const CONTENT_MAX_LENGTH = 20000;
 
 export type TemplateField = "name" | "description" | "hiddenDescription" | "language" | "content";
@@ -112,13 +111,8 @@ function normalizeLanguage(rawLanguage: TemplateLanguage | string): TemplateLang
   throw new TemplateError("Выберите язык шаблона.", "VALIDATION_ERROR", "language");
 }
 
-function normalizeContent(rawContent: string): string {
+function normalizeContent(rawContent?: string | null): string {
   const normalized = (rawContent ?? "").replace(/\r\n/g, "\n");
-  const trimmed = normalized.trim();
-
-  if (trimmed.length < CONTENT_MIN_LENGTH) {
-    throw new TemplateError("Заполните содержимое шаблона.", "VALIDATION_ERROR", "content");
-  }
 
   if (normalized.length > CONTENT_MAX_LENGTH) {
     throw new TemplateError(
@@ -197,7 +191,7 @@ export type TemplateInput = {
   description?: string | null;
   hiddenDescription?: string | null;
   language: TemplateLanguage | string;
-  content: string;
+  content?: string | null;
 };
 
 export type SerializedTemplate = {


### PR DESCRIPTION
## Summary
- add a templates navigation button to the workspace list actions
- reset template dialogs between openings and stop auto-selecting details to avoid stale displays
- make the template content field optional on the client and in service validation

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68d08da89d94832c83d1f8a72fbf7409