### PR TITLE
Fix workspace rooms page slug handling

### DIFF
--- a/src/app/workspaces/[workspaceSlug]/rooms/page.tsx
+++ b/src/app/workspaces/[workspaceSlug]/rooms/page.tsx
@@ -3,7 +3,7 @@ import { notFound, redirect } from "next/navigation";
 import { MemberRole } from "@prisma/client";
 
 import { getCurrentUser } from "@/lib/auth";
-import { findWorkspaceById } from "@/lib/prisma/workspace";
+import { findWorkspaceBySlug } from "@/lib/prisma/workspace";
 import { findMemberByWorkspaceAndUserId } from "@/lib/prisma/member";
 import { listRoomsForWorkspace } from "@/lib/services/room";
 import { ROUTES } from "@/routes";
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
 };
 
 type WorkspaceRoomsPageParams = {
-  workspaceId: string;
+  workspaceSlug: string;
 };
 
 type PageProps = {
@@ -25,15 +25,15 @@ type PageProps = {
 };
 
 export default async function WorkspaceRoomsPage({ params }: PageProps) {
-  const { workspaceId } = await params;
+  const { workspaceSlug } = await params;
 
   const user = await getCurrentUser();
 
   if (!user) {
-    redirect(ROUTES.signin({ callbackUrl: ROUTES.workspaceRooms(workspaceId) }));
+    redirect(ROUTES.signin({ callbackUrl: ROUTES.workspaceRooms(workspaceSlug) }));
   }
 
-  const workspace = await findWorkspaceById(workspaceId);
+  const workspace = await findWorkspaceBySlug(workspaceSlug);
 
   if (!workspace) {
     notFound();


### PR DESCRIPTION
## Summary
- load rooms page workspace data by slug instead of undefined id
- update sign-in redirect callback to use the slug when building the rooms route

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68d5b51dc230832cb33d945c07387775