### PR TITLE
Fix room creation dialog closing behavior

### DIFF
--- a/src/app/workspaces/[workspaceSlug]/rooms/room-form-dialog.tsx
+++ b/src/app/workspaces/[workspaceSlug]/rooms/room-form-dialog.tsx
@@ -64,9 +64,8 @@ export default function RoomFormDialog({
       const message =
         state.message ?? (mode === "create" ? "Комната создана." : "Настройки сохранены.");
       onSuccess(message);
-      onClose();
     }
-  }, [mode, onClose, onSuccess, state.message, state.status]);
+  }, [mode, onSuccess, state.message, state.status]);
 
   const title = mode === "create" ? "Новая комната" : "Настройки комнаты";
   const submitLabel = mode === "create" ? "Создать" : "Сохранить";
@@ -149,7 +148,7 @@ export default function RoomFormDialog({
           </Stack>
         </DialogContent>
         <DialogActions>
-          <Button onClick={onClose} disabled={isPending}>
+          <Button type="button" onClick={onClose} disabled={isPending}>
             Отмена
           </Button>
           <Button type="submit" variant="contained" disabled={isPending}>

--- a/src/app/workspaces/[workspaceSlug]/rooms/rooms-client.tsx
+++ b/src/app/workspaces/[workspaceSlug]/rooms/rooms-client.tsx
@@ -152,6 +152,11 @@ export default function RoomsClient({
     setFeedback({ message, severity });
   };
 
+  const handleFormSuccess = (message: string) => {
+    handleFeedback(message, "success");
+    closeFormDialog();
+  };
+
   const handleCopyLink = async (room: SerializedRoom) => {
     try {
       const origin = typeof window !== "undefined" ? window.location.origin : "";
@@ -384,7 +389,7 @@ export default function RoomsClient({
         workspaceId={workspace.id}
         room={targetRoom}
         onClose={closeFormDialog}
-        onSuccess={handleFeedback}
+        onSuccess={handleFormSuccess}
       />
 
       <RoomCloseDialog


### PR DESCRIPTION
## Summary
- ensure room creation dialog closes from the parent handler after successful submissions
- guard the cancel button from submitting the form to allow immediate closing

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68d5b86acb7c832c92a2d7b0532b7f51