### PR TITLE
feat: implement notification service for user feedback

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import { AppThemeProvider } from "./theme-provider";
+import { NotificationProvider } from "./notification-provider";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -16,7 +17,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <AppThemeProvider>{children}</AppThemeProvider>
+        <AppThemeProvider>
+          <NotificationProvider>{children}</NotificationProvider>
+        </AppThemeProvider>
       </body>
     </html>
   );

--- a/src/app/notification-provider.tsx
+++ b/src/app/notification-provider.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { Alert, Box, Stack } from "@mui/material";
+import type { AlertColor } from "@mui/material";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type PropsWithChildren,
+  type ReactNode,
+} from "react";
+
+type Notification = {
+  id: string;
+  message: ReactNode;
+  severity: AlertColor;
+};
+
+type NotificationInput = {
+  message: ReactNode;
+  severity?: AlertColor;
+  duration?: number;
+};
+
+type NotificationContextValue = {
+  notify: (input: NotificationInput) => string;
+};
+
+const NotificationContext = createContext<NotificationContextValue | undefined>(undefined);
+
+const DEFAULT_DURATION = 6000;
+
+function generateId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return Math.random().toString(36).slice(2);
+}
+
+export function NotificationProvider({ children }: PropsWithChildren) {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const timeouts = useRef<Map<string, number>>(new Map());
+
+  const removeNotification = useCallback((id: string) => {
+    setNotifications((current) => current.filter((notification) => notification.id !== id));
+
+    const timeoutId = timeouts.current.get(id);
+
+    if (timeoutId) {
+      window.clearTimeout(timeoutId);
+      timeouts.current.delete(id);
+    }
+  }, []);
+
+  const notify = useCallback(
+    (input: NotificationInput) => {
+      const id = generateId();
+      const severity = input.severity ?? "info";
+      const duration = input.duration ?? DEFAULT_DURATION;
+
+      setNotifications((current) => [...current, { id, message: input.message, severity }]);
+
+      if (Number.isFinite(duration) && duration > 0) {
+        const timeoutId = window.setTimeout(() => {
+          removeNotification(id);
+        }, duration);
+
+        timeouts.current.set(id, timeoutId);
+      }
+
+      return id;
+    },
+    [removeNotification],
+  );
+
+  const contextValue = useMemo<NotificationContextValue>(() => ({ notify }), [notify]);
+
+  return (
+    <NotificationContext.Provider value={contextValue}>
+      {children}
+      <Box
+        sx={{
+          position: "fixed",
+          bottom: 24,
+          right: 24,
+          display: "flex",
+          flexDirection: "column",
+          gap: 2,
+          zIndex: (theme) => theme.zIndex.snackbar,
+          pointerEvents: "none",
+        }}
+      >
+        <Stack spacing={2} alignItems="flex-end">
+          {notifications.map((notification) => (
+            <Alert
+              key={notification.id}
+              severity={notification.severity}
+              onClose={() => removeNotification(notification.id)}
+              sx={{ pointerEvents: "auto", minWidth: { xs: "100%", sm: 300 } }}
+            >
+              {notification.message}
+            </Alert>
+          ))}
+        </Stack>
+      </Box>
+    </NotificationContext.Provider>
+  );
+}
+
+export function useNotification() {
+  const context = useContext(NotificationContext);
+
+  if (!context) {
+    throw new Error("useNotification must be used within a NotificationProvider");
+  }
+
+  return context.notify;
+}
+
+export type { NotificationInput };

--- a/src/app/signin/signin-form.tsx
+++ b/src/app/signin/signin-form.tsx
@@ -3,9 +3,10 @@
 import { useRouter } from "next/navigation";
 import { FormEvent, useCallback, useState } from "react";
 
-import { Alert, Button, Divider, Stack, TextField, Typography } from "@mui/material";
+import { Button, Divider, Stack, TextField, Typography } from "@mui/material";
 
 import { login } from "@/lib/auth-client";
+import { useNotification } from "@/app/notification-provider";
 
 type SignInFormProps = {
   callbackUrl: string;
@@ -16,12 +17,11 @@ export function SignInForm({ callbackUrl }: SignInFormProps) {
   const [loginValue, setLoginValue] = useState("");
   const [password, setPassword] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const notify = useNotification();
 
   const handleSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
-      setError(null);
       setIsSubmitting(true);
 
       try {
@@ -33,7 +33,7 @@ export function SignInForm({ callbackUrl }: SignInFormProps) {
         });
 
         if (!response || response.error || response.ok === false) {
-          setError("Неверный логин или пароль.");
+          notify({ severity: "error", message: "Неверный логин или пароль." });
           setIsSubmitting(false);
           return;
         }
@@ -43,11 +43,11 @@ export function SignInForm({ callbackUrl }: SignInFormProps) {
         router.refresh();
       } catch (submitError) {
         console.error("Failed to sign in with credentials", submitError);
-        setError("Не удалось выполнить вход. Попробуйте ещё раз.");
+        notify({ severity: "error", message: "Не удалось выполнить вход. Попробуйте ещё раз." });
         setIsSubmitting(false);
       }
     },
-    [callbackUrl, loginValue, password, router],
+    [callbackUrl, loginValue, notify, password, router],
   );
 
   const handleGoogleSignIn = useCallback(() => {
@@ -64,8 +64,6 @@ export function SignInForm({ callbackUrl }: SignInFormProps) {
           Укажите учётные данные, выданные вашей командой.
         </Typography>
       </Stack>
-
-      {error ? <Alert severity="error">{error}</Alert> : null}
 
       <Stack spacing={2}>
         <TextField

--- a/src/app/workspaces/[workspaceSlug]/rooms/room-close-dialog.tsx
+++ b/src/app/workspaces/[workspaceSlug]/rooms/room-close-dialog.tsx
@@ -2,7 +2,6 @@
 
 import { useActionState, useEffect } from "react";
 import {
-  Alert,
   Button,
   CircularProgress,
   Dialog,
@@ -16,6 +15,7 @@ import type { SerializedRoom } from "@/lib/services/room";
 
 import { closeRoomAction } from "./actions";
 import { roomActionIdleState } from "./room-action-state";
+import { useNotification } from "@/app/notification-provider";
 
 type RoomCloseDialogProps = {
   open: boolean;
@@ -33,6 +33,7 @@ export default function RoomCloseDialog({
   onSuccess,
 }: RoomCloseDialogProps) {
   const [state, formAction, isPending] = useActionState(closeRoomAction, roomActionIdleState);
+  const notify = useNotification();
 
   useEffect(() => {
     if (state.status === "success") {
@@ -40,6 +41,12 @@ export default function RoomCloseDialog({
       onClose();
     }
   }, [onClose, onSuccess, state.message, state.status]);
+
+  useEffect(() => {
+    if (state.status === "error" && state.message) {
+      notify({ severity: "error", message: state.message });
+    }
+  }, [notify, state.message, state.status]);
 
   const roomName = room?.name ?? "";
 
@@ -57,11 +64,6 @@ export default function RoomCloseDialog({
           <Typography color="text.secondary">
             Вы уверены, что хотите закрыть комнату «{roomName}»?
           </Typography>
-          {state.status === "error" && state.message ? (
-            <Alert severity="error" sx={{ mt: 2 }}>
-              {state.message}
-            </Alert>
-          ) : null}
         </DialogContent>
         <DialogActions>
           <Button onClick={onClose} disabled={isPending}>

--- a/src/app/workspaces/[workspaceSlug]/rooms/room-form-dialog.tsx
+++ b/src/app/workspaces/[workspaceSlug]/rooms/room-form-dialog.tsx
@@ -2,7 +2,6 @@
 
 import { useActionState, useEffect, useMemo, useState } from "react";
 import {
-  Alert,
   Button,
   CircularProgress,
   Dialog,
@@ -16,6 +15,7 @@ import {
 } from "@mui/material";
 
 import type { SerializedRoom } from "@/lib/services/room";
+import { useNotification } from "@/app/notification-provider";
 
 import { createRoomAction, updateRoomAction } from "./actions";
 import { roomActionIdleState } from "./room-action-state";
@@ -42,6 +42,7 @@ export default function RoomFormDialog({
   const action = useMemo(() => (mode === "create" ? createRoomAction : updateRoomAction), [mode]);
 
   const [state, formAction, isPending] = useActionState(action, roomActionIdleState);
+  const notify = useNotification();
 
   const [name, setName] = useState(room?.name ?? "");
   const [code, setCode] = useState(room?.code ?? "");
@@ -67,6 +68,12 @@ export default function RoomFormDialog({
     }
   }, [mode, onSuccess, state.message, state.status]);
 
+  useEffect(() => {
+    if (state.status === "error" && state.message) {
+      notify({ severity: "error", message: state.message });
+    }
+  }, [notify, state.message, state.status]);
+
   const title = mode === "create" ? "Новая комната" : "Настройки комнаты";
   const submitLabel = mode === "create" ? "Создать" : "Сохранить";
 
@@ -81,9 +88,6 @@ export default function RoomFormDialog({
         <DialogTitle>{title}</DialogTitle>
         <DialogContent dividers>
           <Stack spacing={2} sx={{ mt: 1 }}>
-            {state.status === "error" && state.message ? (
-              <Alert severity="error">{state.message}</Alert>
-            ) : null}
             <TextField
               label="Название"
               name="name"

--- a/src/app/workspaces/[workspaceSlug]/rooms/room-slug-dialog.tsx
+++ b/src/app/workspaces/[workspaceSlug]/rooms/room-slug-dialog.tsx
@@ -2,7 +2,6 @@
 
 import { useActionState, useEffect } from "react";
 import {
-  Alert,
   Button,
   CircularProgress,
   Dialog,
@@ -16,6 +15,7 @@ import type { SerializedRoom } from "@/lib/services/room";
 
 import { regenerateRoomSlugAction } from "./actions";
 import { roomActionIdleState } from "./room-action-state";
+import { useNotification } from "@/app/notification-provider";
 
 type RoomSlugDialogProps = {
   open: boolean;
@@ -36,6 +36,7 @@ export default function RoomSlugDialog({
     regenerateRoomSlugAction,
     roomActionIdleState,
   );
+  const notify = useNotification();
 
   useEffect(() => {
     if (state.status === "success") {
@@ -43,6 +44,12 @@ export default function RoomSlugDialog({
       onClose();
     }
   }, [onClose, onSuccess, state.message, state.status]);
+
+  useEffect(() => {
+    if (state.status === "error" && state.message) {
+      notify({ severity: "error", message: state.message });
+    }
+  }, [notify, state.message, state.status]);
 
   return (
     <Dialog open={open} onClose={isPending ? undefined : onClose} maxWidth="sm" fullWidth>
@@ -58,11 +65,6 @@ export default function RoomSlugDialog({
           <Typography color="text.secondary">
             Текущая ссылка: <strong>{room?.slug}</strong>
           </Typography>
-          {state.status === "error" && state.message ? (
-            <Alert severity="error" sx={{ mt: 2 }}>
-              {state.message}
-            </Alert>
-          ) : null}
         </DialogContent>
         <DialogActions>
           <Button onClick={onClose} disabled={isPending}>

--- a/src/app/workspaces/[workspaceSlug]/templates/template-delete-dialog.tsx
+++ b/src/app/workspaces/[workspaceSlug]/templates/template-delete-dialog.tsx
@@ -2,7 +2,6 @@
 
 import { useActionState, useEffect } from "react";
 import {
-  Alert,
   Button,
   CircularProgress,
   Dialog,
@@ -17,6 +16,7 @@ import type { SerializedTemplate } from "@/lib/services/template";
 
 import { deleteTemplateAction } from "./actions";
 import { templateActionIdleState } from "./template-action-state";
+import { useNotification } from "@/app/notification-provider";
 
 type TemplateDeleteDialogProps = {
   open: boolean;
@@ -37,6 +37,7 @@ export default function TemplateDeleteDialog({
     deleteTemplateAction,
     templateActionIdleState,
   );
+  const notify = useNotification();
 
   useEffect(() => {
     if (state.status === "success") {
@@ -44,6 +45,12 @@ export default function TemplateDeleteDialog({
       onClose();
     }
   }, [onClose, onSuccess, state.message, state.status]);
+
+  useEffect(() => {
+    if (state.status === "error" && state.message) {
+      notify({ severity: "error", message: state.message });
+    }
+  }, [notify, state.message, state.status]);
 
   return (
     <Dialog open={open} onClose={isPending ? undefined : onClose} fullWidth maxWidth="sm">
@@ -53,9 +60,6 @@ export default function TemplateDeleteDialog({
         <DialogTitle>Удалить шаблон</DialogTitle>
         <DialogContent dividers>
           <Stack spacing={2} sx={{ pt: 1 }}>
-            {state.status === "error" && state.message ? (
-              <Alert severity="error">{state.message}</Alert>
-            ) : null}
             <Typography>
               Вы уверены, что хотите удалить шаблон <strong>{template?.name}</strong>? Действие
               нельзя отменить.

--- a/src/app/workspaces/[workspaceSlug]/templates/template-form.tsx
+++ b/src/app/workspaces/[workspaceSlug]/templates/template-form.tsx
@@ -3,7 +3,6 @@
 import { type ReactNode, useActionState, useEffect, useMemo, useState } from "react";
 import type { TemplateLanguage } from "@prisma/client";
 import {
-  Alert,
   Button,
   CircularProgress,
   FormControl,
@@ -19,6 +18,7 @@ import type { SerializedTemplate } from "@/lib/services/template";
 
 import { createTemplateAction, updateTemplateAction } from "./actions";
 import { templateActionIdleState } from "./template-action-state";
+import { useNotification } from "@/app/notification-provider";
 
 export type TemplateFormMode = "create" | "edit";
 
@@ -59,6 +59,7 @@ export default function TemplateForm({
   );
 
   const [state, formAction, isPending] = useActionState(action, templateActionIdleState);
+  const notify = useNotification();
 
   useEffect(() => {
     onPendingChange?.(isPending);
@@ -86,14 +87,17 @@ export default function TemplateForm({
     }
   }, [mode, onSuccess, state.message, state.status]);
 
+  useEffect(() => {
+    if (state.status === "error" && state.message) {
+      notify({ severity: "error", message: state.message });
+    }
+  }, [notify, state.message, state.status]);
+
   const resolvedSubmitLabel = submitLabel ?? (mode === "create" ? "Создать" : "Сохранить");
   const resolvedCancelLabel = cancelLabel ?? "Отмена";
 
   const fields = (
     <Stack spacing={2} sx={{ mt: 1 }}>
-      {state.status === "error" && state.message ? (
-        <Alert severity="error">{state.message}</Alert>
-      ) : null}
       <TextField
         label="Название"
         name="name"

--- a/src/app/workspaces/workspaces-client.tsx
+++ b/src/app/workspaces/workspaces-client.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import type { ChangeEvent } from "react";
-import { useActionState, useEffect, useMemo, useState, useTransition } from "react";
+import { useActionState, useCallback, useEffect, useMemo, useState, useTransition } from "react";
 import type { MemberRole } from "@prisma/client";
 
 import {
   Avatar,
-  Alert,
   Box,
   Button,
   Card,
@@ -18,7 +17,6 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  Snackbar,
   Stack,
   Table,
   TableBody,
@@ -37,6 +35,7 @@ import { logout } from "@/lib/auth-client";
 
 import { ROUTES } from "@/routes";
 import Link from "next/link";
+import { useNotification } from "@/app/notification-provider";
 
 type SerializedWorkspace = {
   id: string;
@@ -59,11 +58,6 @@ type WorkspacesClientProps = {
   workspaces: SerializedWorkspace[];
   currentUser: CurrentUserSummary;
 };
-
-type FeedbackState = {
-  message: string;
-  severity: "success" | "error";
-} | null;
 
 const idleState: WorkspaceActionState = { status: "idle" };
 
@@ -149,6 +143,14 @@ function CreateWorkspaceDialog({ open, onClose, onSuccess }: WorkspaceFormProps)
     }
   }, [onClose, onSuccess, state.status]);
 
+  const notify = useNotification();
+
+  useEffect(() => {
+    if (state.status === "error" && state.message) {
+      notify({ severity: "error", message: state.message });
+    }
+  }, [notify, state.message, state.status]);
+
   const handleSlugChange = (event: ChangeEvent<HTMLInputElement>) => {
     const rawValue = event.target.value;
 
@@ -168,9 +170,6 @@ function CreateWorkspaceDialog({ open, onClose, onSuccess }: WorkspaceFormProps)
         <DialogTitle>Создать рабочую область</DialogTitle>
         <DialogContent sx={{ pt: 1 }}>
           <Stack spacing={2} mt={1}>
-            {state.status === "error" && state.message ? (
-              <Alert severity="error">{state.message}</Alert>
-            ) : null}
             <TextField
               autoFocus
               label="Название"
@@ -232,6 +231,14 @@ function EditWorkspaceDialog({ open, onClose, onSuccess, workspace }: EditWorksp
     }
   }, [onClose, onSuccess, state.status]);
 
+  const notify = useNotification();
+
+  useEffect(() => {
+    if (state.status === "error" && state.message) {
+      notify({ severity: "error", message: state.message });
+    }
+  }, [notify, state.message, state.status]);
+
   const handleSlugChange = (event: ChangeEvent<HTMLInputElement>) => {
     const rawValue = event.target.value;
 
@@ -263,9 +270,6 @@ function EditWorkspaceDialog({ open, onClose, onSuccess, workspace }: EditWorksp
         <DialogTitle>Редактировать рабочую область</DialogTitle>
         <DialogContent sx={{ pt: 1 }}>
           <Stack spacing={2} mt={1}>
-            {state.status === "error" && state.message ? (
-              <Alert severity="error">{state.message}</Alert>
-            ) : null}
             <TextField
               autoFocus
               label="Название"
@@ -319,14 +323,8 @@ function DeleteWorkspaceDialog({
   onSuccess,
   workspace,
 }: DeleteWorkspaceDialogProps) {
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
-
-  useEffect(() => {
-    if (!open) {
-      setErrorMessage(null);
-    }
-  }, [open]);
+  const notify = useNotification();
 
   if (!workspace) {
     return null;
@@ -340,7 +338,7 @@ function DeleteWorkspaceDialog({
         onSuccess("Рабочая область удалена.");
         onClose();
       } else if (result.message) {
-        setErrorMessage(result.message);
+        notify({ severity: "error", message: result.message });
       }
     });
   };
@@ -350,7 +348,6 @@ function DeleteWorkspaceDialog({
       <DialogTitle>Удалить рабочую область</DialogTitle>
       <DialogContent sx={{ pt: 1 }}>
         <Stack spacing={2} mt={1}>
-          {errorMessage ? <Alert severity="error">{errorMessage}</Alert> : null}
           <Typography>
             Вы уверены, что хотите удалить рабочую область «{workspace.name}»? Это действие нельзя
             отменить.
@@ -374,7 +371,7 @@ export function WorkspacesClient({ workspaces, currentUser }: WorkspacesClientPr
   const [createOpen, setCreateOpen] = useState(false);
   const [editWorkspace, setEditWorkspace] = useState<SerializedWorkspace | null>(null);
   const [deleteWorkspace, setDeleteWorkspace] = useState<SerializedWorkspace | null>(null);
-  const [feedback, setFeedback] = useState<FeedbackState>(null);
+  const notify = useNotification();
   const [createKey, setCreateKey] = useState(0);
   const [editKey, setEditKey] = useState(0);
   const [deleteKey, setDeleteKey] = useState(0);
@@ -395,9 +392,12 @@ export function WorkspacesClient({ workspaces, currentUser }: WorkspacesClientPr
     });
   };
 
-  const handleFeedback = (message: string) => {
-    setFeedback({ message, severity: "success" });
-  };
+  const handleFeedback = useCallback(
+    (message: string) => {
+      notify({ message, severity: "success" });
+    },
+    [notify],
+  );
 
   const closeCreate = () => {
     setCreateOpen(false);
@@ -582,17 +582,6 @@ export function WorkspacesClient({ workspaces, currentUser }: WorkspacesClientPr
         onSuccess={handleFeedback}
         workspace={deleteWorkspace}
       />
-
-      {feedback ? (
-        <Snackbar
-          open
-          autoHideDuration={5000}
-          onClose={() => setFeedback(null)}
-          anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
-        >
-          <Alert severity={feedback.severity}>{feedback.message}</Alert>
-        </Snackbar>
-      ) : null}
     </Container>
   );
 }


### PR DESCRIPTION
## Summary
- add a global notification provider with stackable auto-dismissing alerts
- wrap the application layout with the notification service
- migrate action feedback across rooms, templates, members, workspaces, and sign-in flows to use notifications

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dd2dd808e4832cbd60320516e4cdca