### PR TITLE
Refactor room utilities for shared usage

### DIFF
--- a/src/app/rooms/[roomSlug]/room-settings-client.tsx
+++ b/src/app/rooms/[roomSlug]/room-settings-client.tsx
@@ -24,6 +24,12 @@ import RoomFormDialog from "@/app/workspaces/[workspaceSlug]/rooms/room-form-dia
 import RoomCloseDialog from "@/app/workspaces/[workspaceSlug]/rooms/room-close-dialog";
 import RoomSlugDialog from "@/app/workspaces/[workspaceSlug]/rooms/room-slug-dialog";
 import { updateRoomAction } from "@/app/workspaces/[workspaceSlug]/rooms/actions";
+import {
+  copyRoomLink,
+  formatRoomDate,
+  ROOM_STATUS_COLORS,
+  ROOM_STATUS_LABELS,
+} from "@/app/workspaces/[workspaceSlug]/rooms/room-utils";
 
 export type WorkspaceSummary = {
   id: string;
@@ -38,33 +44,6 @@ type RoomSettingsClientProps = {
   viewerRole: MemberRole | null;
 };
 
-const STATUS_LABELS: Record<RoomStatus, string> = {
-  ACTIVE: "Активна",
-  CLOSED: "Закрыта",
-  ARCHIVED: "В архиве",
-};
-
-const STATUS_COLOR: Record<RoomStatus, "default" | "success" | "warning"> = {
-  ACTIVE: "success",
-  CLOSED: "default",
-  ARCHIVED: "warning",
-};
-
-function formatDate(value: string | null): string {
-  if (!value) {
-    return "—";
-  }
-
-  try {
-    return new Intl.DateTimeFormat("ru-RU", {
-      dateStyle: "medium",
-      timeStyle: "short",
-    }).format(new Date(value));
-  } catch {
-    return value;
-  }
-}
-
 export default function RoomSettingsClient({
   room,
   workspace,
@@ -76,8 +55,8 @@ export default function RoomSettingsClient({
   const [closeRoomTarget, setCloseRoomTarget] = useState<SerializedRoom | null>(null);
   const [slugRoomTarget, setSlugRoomTarget] = useState<SerializedRoom | null>(null);
 
-  const statusLabel = STATUS_LABELS[room.status];
-  const statusColor = STATUS_COLOR[room.status];
+  const statusLabel = ROOM_STATUS_LABELS[room.status];
+  const statusColor = ROOM_STATUS_COLORS[room.status];
 
   const anonChips = useMemo(() => {
     return [
@@ -96,9 +75,7 @@ export default function RoomSettingsClient({
 
   const handleCopyLink = async () => {
     try {
-      const origin = typeof window !== "undefined" ? window.location.origin : "";
-      const url = `${origin}${ROUTES.room(room.slug)}`;
-      await navigator.clipboard.writeText(url);
+      await copyRoomLink(room.slug);
       handleFeedback("Ссылка скопирована.");
     } catch (error) {
       console.error(error);
@@ -166,7 +143,7 @@ export default function RoomSettingsClient({
                 variant={statusColor === "default" ? "outlined" : "filled"}
               />
               <Chip
-                label={`Обновлено ${formatDate(room.updatedAt)}`}
+                label={`Обновлено ${formatRoomDate(room.updatedAt)}`}
                 variant="outlined"
                 size="small"
               />
@@ -221,10 +198,10 @@ export default function RoomSettingsClient({
                 ))}
               </Stack>
               <Typography variant="body2" color="text.secondary">
-                Создана: {formatDate(room.createdAt)}
+                Создана: {formatRoomDate(room.createdAt)}
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                Закрыта: {formatDate(room.closedAt)}
+                Закрыта: {formatRoomDate(room.closedAt)}
               </Typography>
               {canManage ? (
                 <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>

--- a/src/app/workspaces/[workspaceSlug]/rooms/room-utils.ts
+++ b/src/app/workspaces/[workspaceSlug]/rooms/room-utils.ts
@@ -1,0 +1,37 @@
+import type { ChipProps } from "@mui/material";
+import { RoomStatus } from "@prisma/client";
+
+import { ROUTES } from "@/routes";
+
+export const ROOM_STATUS_LABELS: Record<RoomStatus, string> = {
+  ACTIVE: "Активна",
+  CLOSED: "Закрыта",
+  ARCHIVED: "В архиве",
+};
+
+export const ROOM_STATUS_COLORS: Record<RoomStatus, ChipProps["color"]> = {
+  ACTIVE: "success",
+  CLOSED: "default",
+  ARCHIVED: "warning",
+};
+
+export function formatRoomDate(value: string | null): string {
+  if (!value) {
+    return "—";
+  }
+
+  try {
+    return new Intl.DateTimeFormat("ru-RU", {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(value));
+  } catch {
+    return value;
+  }
+}
+
+export async function copyRoomLink(slug: string): Promise<void> {
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const url = `${origin}${ROUTES.room(slug)}`;
+  await navigator.clipboard.writeText(url);
+}

--- a/src/app/workspaces/[workspaceSlug]/rooms/rooms-client.tsx
+++ b/src/app/workspaces/[workspaceSlug]/rooms/rooms-client.tsx
@@ -23,6 +23,8 @@ import {
 import type { SerializedRoom } from "@/lib/services/room";
 import { ROUTES } from "@/routes";
 
+import { copyRoomLink, formatRoomDate, ROOM_STATUS_COLORS, ROOM_STATUS_LABELS } from "./room-utils";
+
 import RoomFormDialog from "./room-form-dialog";
 import RoomCloseDialog from "./room-close-dialog";
 import RoomSlugDialog from "./room-slug-dialog";
@@ -49,33 +51,6 @@ type RoomsClientProps = {
   canManage: boolean;
   currentUser: CurrentUserSummary;
 };
-
-const STATUS_LABELS: Record<RoomStatus, string> = {
-  ACTIVE: "Активна",
-  CLOSED: "Закрыта",
-  ARCHIVED: "В архиве",
-};
-
-const STATUS_COLOR: Record<RoomStatus, "default" | "success" | "warning"> = {
-  ACTIVE: "success",
-  CLOSED: "default",
-  ARCHIVED: "warning",
-};
-
-function formatDate(value: string | null): string {
-  if (!value) {
-    return "—";
-  }
-
-  try {
-    return new Intl.DateTimeFormat("ru-RU", {
-      dateStyle: "medium",
-      timeStyle: "short",
-    }).format(new Date(value));
-  } catch {
-    return value;
-  }
-}
 
 export default function RoomsClient({
   workspace,
@@ -138,9 +113,7 @@ export default function RoomsClient({
 
   const handleCopyLink = async (room: SerializedRoom) => {
     try {
-      const origin = typeof window !== "undefined" ? window.location.origin : "";
-      const url = `${origin}${ROUTES.room(room.slug)}`;
-      await navigator.clipboard.writeText(url);
+      await copyRoomLink(room.slug);
       handleFeedback("Ссылка скопирована.");
     } catch (error) {
       console.error(error);
@@ -254,8 +227,8 @@ export default function RoomsClient({
                 </TableHead>
                 <TableBody>
                   {sortedRooms.map((room) => {
-                    const statusColor = STATUS_COLOR[room.status];
-                    const statusLabel = STATUS_LABELS[room.status];
+                    const statusColor = ROOM_STATUS_COLORS[room.status];
+                    const statusLabel = ROOM_STATUS_LABELS[room.status];
 
                     return (
                       <TableRow key={room.id} hover>
@@ -263,7 +236,7 @@ export default function RoomsClient({
                           <Stack spacing={0.5}>
                             <Typography fontWeight={600}>{room.name}</Typography>
                             <Typography color="text.secondary" variant="body2">
-                              Создана {formatDate(room.createdAt)}
+                              Создана {formatRoomDate(room.createdAt)}
                             </Typography>
                           </Stack>
                         </TableCell>
@@ -308,7 +281,7 @@ export default function RoomsClient({
                             </Button>
                           </Stack>
                         </TableCell>
-                        <TableCell>{formatDate(room.updatedAt)}</TableCell>
+                        <TableCell>{formatRoomDate(room.updatedAt)}</TableCell>
                         <TableCell align="right">
                           <Stack direction="row" spacing={1} justifyContent="flex-end">
                             <Button


### PR DESCRIPTION
## Summary
- extract shared room status helpers, date formatting, and link copy logic into a reusable module
- update room list and settings clients to consume the shared utilities

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dd3c42d3b0832c8ba6bec4b448887b