### PR TITLE
Align member and room dialogs with shared form pattern

### DIFF
--- a/src/lib/services/__tests__/room.test.ts
+++ b/src/lib/services/__tests__/room.test.ts
@@ -168,7 +168,7 @@ describe("RoomService", () => {
       createRoom(viewerMembership.userId, workspace.id, {
         name: "Интервью",
       }),
-    ).rejects.toMatchObject<Partial<RoomError>>({ code: "FORBIDDEN" });
+    ).rejects.toMatchObject({ code: "FORBIDDEN" } satisfies Partial<RoomError>);
 
     expect(mockedRoomRepo.createRoomRecord).not.toHaveBeenCalled();
   });
@@ -181,7 +181,7 @@ describe("RoomService", () => {
       .mockReturnValue(0.654321);
 
     mockedRoomRepo.findRoomBySlug
-      .mockImplementationOnce(async () => ({ ...baseRoom, id: "room-2" }))
+      .mockImplementationOnce(async () => ({ ...baseRoom, id: "room-2", workspace }))
       .mockImplementationOnce(async () => null);
 
     const slug = await generateUniqueSlug("Интервью по JS");
@@ -194,7 +194,7 @@ describe("RoomService", () => {
 
   it("appends suffix when custom slug already exists", async () => {
     mockedRoomRepo.findRoomBySlug
-      .mockImplementationOnce(async () => ({ ...baseRoom, id: "room-2" }))
+      .mockImplementationOnce(async () => ({ ...baseRoom, id: "room-2", workspace }))
       .mockImplementationOnce(async () => null);
 
     const slug = await generateUniqueSlug("Интервью по JS", { slug: "custom" });

--- a/src/lib/services/__tests__/template.test.ts
+++ b/src/lib/services/__tests__/template.test.ts
@@ -108,10 +108,10 @@ describe("TemplateService", () => {
         language: TemplateLanguage.JAVASCRIPT,
         content: "console.log(1);",
       }),
-    ).rejects.toMatchObject<Partial<TemplateError>>({
+    ).rejects.toMatchObject({
       code: "VALIDATION_ERROR",
       field: "name",
-    });
+    } satisfies Partial<TemplateError>);
 
     expect(mockedTemplateRepo.createTemplate).not.toHaveBeenCalled();
   });
@@ -125,10 +125,10 @@ describe("TemplateService", () => {
         language: TemplateLanguage.JAVASCRIPT,
         content: "console.log('test');",
       }),
-    ).rejects.toMatchObject<Partial<TemplateError>>({
+    ).rejects.toMatchObject({
       code: "VALIDATION_ERROR",
       field: "hiddenDescription",
-    });
+    } satisfies Partial<TemplateError>);
 
     expect(mockedTemplateRepo.createTemplate).not.toHaveBeenCalled();
   });
@@ -169,7 +169,7 @@ describe("TemplateService", () => {
         language: TemplateLanguage.REACT,
         content: "export const Component = () => null;",
       }),
-    ).rejects.toMatchObject<Partial<TemplateError>>({ code: "FORBIDDEN" });
+    ).rejects.toMatchObject({ code: "FORBIDDEN" } satisfies Partial<TemplateError>);
 
     expect(mockedTemplateRepo.createTemplate).not.toHaveBeenCalled();
   });

--- a/src/shared/forms.ts
+++ b/src/shared/forms.ts
@@ -11,7 +11,7 @@ const withHandlers =
   };
 
 export const useForm = <T extends object, ActionState extends object>(
-  current: T,
+  current: Partial<T> | null | undefined,
   action: (prevState: Awaited<ActionState>, data: FormData) => Promise<ActionState>,
   initialActionState: Awaited<ActionState>,
   onSuccess: () => void,
@@ -26,11 +26,11 @@ export const useForm = <T extends object, ActionState extends object>(
     initialActionState,
   );
 
-  const formValue: T = {
+  const formValue = {
     ...initialFormValue,
-    ...current,
+    ...(current ?? {}),
     ...localFormData,
-  };
+  } as T;
 
   const set =
     <Key extends keyof T>(key: Key) =>


### PR DESCRIPTION
## Summary
- reset workspace member invite/change/remove dialogs to rely on `useForm` defaults with inline error alerts
- type the room slug dialog form state so hidden inputs stay in sync with `useForm`
- allow the template form to consume serialized template data directly while normalizing nullable descriptions

## Testing
- yarn tsc --noEmit
- yarn lint
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68dd49238690832ca157696027c7f836