### PR TITLE
Add room presence domain and service

### DIFF
--- a/prisma/migrations/20250924000000_add_room_presence/migration.sql
+++ b/prisma/migrations/20250924000000_add_room_presence/migration.sql
@@ -1,0 +1,74 @@
+-- CreateEnum
+CREATE TYPE "AnonymousApprovalMode" AS ENUM ('AUTO', 'MANUAL');
+
+-- CreateEnum
+CREATE TYPE "RoomParticipantRole" AS ENUM ('HOST', 'COLLABORATOR', 'VIEWER', 'GUEST');
+
+-- CreateEnum
+CREATE TYPE "RoomParticipantSource" AS ENUM ('WORKSPACE_MEMBER', 'ANONYMOUS');
+
+-- AlterTable
+ALTER TABLE "Room"
+  ADD COLUMN "requiresMemberAccount" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "anonymousApprovalMode" "AnonymousApprovalMode" NOT NULL DEFAULT 'AUTO',
+  ADD COLUMN "maxParticipants" INTEGER;
+
+-- CreateTable
+CREATE TABLE "RoomAnonymousProfile" (
+    "id" TEXT NOT NULL,
+    "roomId" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "slugToken" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "RoomAnonymousProfile_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RoomParticipant" (
+    "id" TEXT NOT NULL,
+    "roomId" TEXT NOT NULL,
+    "userId" TEXT,
+    "anonymousProfileId" TEXT,
+    "role" "RoomParticipantRole" NOT NULL,
+    "source" "RoomParticipantSource" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "RoomParticipant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RoomSession" (
+    "id" TEXT NOT NULL,
+    "roomId" TEXT NOT NULL,
+    "participantId" TEXT NOT NULL,
+    "connectionId" TEXT NOT NULL,
+    "clientInfo" JSONB,
+    "connectedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "disconnectedAt" TIMESTAMP(3),
+    "lastPingAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "RoomSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RoomAnonymousProfile_slugToken_key" ON "RoomAnonymousProfile"("slugToken");
+CREATE INDEX "RoomAnonymousProfile_roomId_idx" ON "RoomAnonymousProfile"("roomId");
+
+CREATE UNIQUE INDEX "RoomParticipant_roomId_userId_key" ON "RoomParticipant"("roomId", "userId");
+CREATE UNIQUE INDEX "RoomParticipant_roomId_anonymousProfileId_key" ON "RoomParticipant"("roomId", "anonymousProfileId");
+CREATE INDEX "RoomParticipant_roomId_idx" ON "RoomParticipant"("roomId");
+
+CREATE UNIQUE INDEX "RoomSession_connectionId_key" ON "RoomSession"("connectionId");
+CREATE INDEX "RoomSession_roomId_idx" ON "RoomSession"("roomId");
+CREATE INDEX "RoomSession_participantId_idx" ON "RoomSession"("participantId");
+
+-- AddForeignKey
+ALTER TABLE "RoomAnonymousProfile" ADD CONSTRAINT "RoomAnonymousProfile_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "Room"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "RoomParticipant" ADD CONSTRAINT "RoomParticipant_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "Room"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "RoomParticipant" ADD CONSTRAINT "RoomParticipant_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "RoomParticipant" ADD CONSTRAINT "RoomParticipant_anonymousProfileId_fkey" FOREIGN KEY ("anonymousProfileId") REFERENCES "RoomAnonymousProfile"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "RoomSession" ADD CONSTRAINT "RoomSession_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "Room"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "RoomSession" ADD CONSTRAINT "RoomSession_participantId_fkey" FOREIGN KEY ("participantId") REFERENCES "RoomParticipant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
   invitedMembers Member[] @relation("MemberInvitedBy")
   templates     Template[]
   createdRooms  Room[]
+  roomParticipants RoomParticipant[]
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 }
@@ -93,6 +94,23 @@ enum RoomStatus {
   ARCHIVED
 }
 
+enum AnonymousApprovalMode {
+  AUTO
+  MANUAL
+}
+
+enum RoomParticipantRole {
+  HOST
+  COLLABORATOR
+  VIEWER
+  GUEST
+}
+
+enum RoomParticipantSource {
+  WORKSPACE_MEMBER
+  ANONYMOUS
+}
+
 model Member {
   id           String     @id @default(cuid())
   workspaceId  String
@@ -146,6 +164,9 @@ model Room {
   allowAnonymousView  Boolean     @default(false)
   allowAnonymousEdit  Boolean     @default(false)
   allowAnonymousJoin  Boolean     @default(false)
+  requiresMemberAccount Boolean   @default(false)
+  anonymousApprovalMode AnonymousApprovalMode @default(AUTO)
+  maxParticipants      Int?
   code                String      @default("")
   archivedAt          DateTime?
   closedAt            DateTime?
@@ -154,7 +175,61 @@ model Room {
 
   workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
   createdBy User      @relation(fields: [createdById], references: [id], onDelete: Cascade)
+  participants RoomParticipant[]
+  anonymousProfiles RoomAnonymousProfile[]
+  sessions RoomSession[]
 
   @@index([workspaceId])
   @@unique([workspaceId, name])
+}
+
+model RoomParticipant {
+  id                 String                  @id @default(cuid())
+  roomId             String
+  userId             String?
+  anonymousProfileId String?
+  role               RoomParticipantRole
+  source             RoomParticipantSource
+  createdAt          DateTime                @default(now())
+  updatedAt          DateTime                @updatedAt
+
+  room             Room                  @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  user             User?                 @relation(fields: [userId], references: [id], onDelete: Cascade)
+  anonymousProfile RoomAnonymousProfile? @relation(fields: [anonymousProfileId], references: [id], onDelete: Cascade)
+  sessions         RoomSession[]
+
+  @@index([roomId])
+  @@unique([roomId, userId])
+  @@unique([roomId, anonymousProfileId])
+}
+
+model RoomAnonymousProfile {
+  id         String   @id @default(cuid())
+  roomId     String
+  displayName String
+  slugToken  String   @unique
+  createdAt  DateTime @default(now())
+  lastUsedAt DateTime @default(now())
+
+  room         Room             @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  participants RoomParticipant[]
+
+  @@index([roomId])
+}
+
+model RoomSession {
+  id            String   @id @default(cuid())
+  roomId        String
+  participantId String
+  connectionId  String   @unique
+  clientInfo    Json?
+  connectedAt   DateTime @default(now())
+  disconnectedAt DateTime?
+  lastPingAt    DateTime @default(now())
+
+  room        Room            @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  participant RoomParticipant @relation(fields: [participantId], references: [id], onDelete: Cascade)
+
+  @@index([roomId])
+  @@index([participantId])
 }

--- a/src/lib/prisma/roomMember.ts
+++ b/src/lib/prisma/roomMember.ts
@@ -1,0 +1,219 @@
+import type { Prisma, RoomAnonymousProfile, RoomSession } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+
+const baseParticipantInclude = {
+  user: true,
+  anonymousProfile: true,
+} satisfies Prisma.RoomParticipantInclude;
+
+const participantWithSessionsInclude = {
+  ...baseParticipantInclude,
+  sessions: {
+    where: { disconnectedAt: null },
+    orderBy: { connectedAt: "desc" as const },
+  },
+} satisfies Prisma.RoomParticipantInclude;
+
+export type RoomParticipantWithRelations = Prisma.RoomParticipantGetPayload<{
+  include: typeof baseParticipantInclude;
+}>;
+
+export type RoomParticipantWithActiveSessions = Prisma.RoomParticipantGetPayload<{
+  include: typeof participantWithSessionsInclude;
+}>;
+
+type TransactionClient = Prisma.TransactionClient;
+type ClientLike = typeof prisma | TransactionClient;
+
+function resolveClient(client?: TransactionClient): ClientLike {
+  return client ?? prisma;
+}
+
+export async function findRoomParticipantByUserId(
+  roomId: string,
+  userId: string,
+  client?: TransactionClient,
+): Promise<RoomParticipantWithRelations | null> {
+  const db = resolveClient(client);
+
+  return db.roomParticipant.findFirst({
+    where: { roomId, userId },
+    include: baseParticipantInclude,
+  });
+}
+
+export async function findRoomParticipantByAnonymousProfileId(
+  roomId: string,
+  anonymousProfileId: string,
+  client?: TransactionClient,
+): Promise<RoomParticipantWithRelations | null> {
+  const db = resolveClient(client);
+
+  return db.roomParticipant.findFirst({
+    where: { roomId, anonymousProfileId },
+    include: baseParticipantInclude,
+  });
+}
+
+export async function createRoomParticipant(
+  data: Prisma.RoomParticipantCreateArgs["data"],
+  client?: TransactionClient,
+): Promise<RoomParticipantWithRelations> {
+  const db = resolveClient(client);
+
+  return db.roomParticipant.create({
+    data,
+    include: baseParticipantInclude,
+  });
+}
+
+export async function updateRoomParticipant(
+  id: string,
+  data: Prisma.RoomParticipantUpdateArgs["data"],
+  client?: TransactionClient,
+): Promise<RoomParticipantWithRelations> {
+  const db = resolveClient(client);
+
+  return db.roomParticipant.update({
+    where: { id },
+    data,
+    include: baseParticipantInclude,
+  });
+}
+
+export async function listRoomParticipantsWithSessions(
+  roomId: string,
+  client?: TransactionClient,
+): Promise<RoomParticipantWithActiveSessions[]> {
+  const db = resolveClient(client);
+
+  return db.roomParticipant.findMany({
+    where: { roomId },
+    include: participantWithSessionsInclude,
+    orderBy: [{ user: { name: "asc" } }, { createdAt: "asc" }],
+  });
+}
+
+export async function listActiveParticipantIds(
+  roomId: string,
+  client?: TransactionClient,
+): Promise<string[]> {
+  const db = resolveClient(client);
+
+  const rows = await db.roomSession.findMany({
+    where: { roomId, disconnectedAt: null },
+    select: { participantId: true },
+  });
+
+  const unique = new Set(rows.map((row) => row.participantId));
+  return Array.from(unique.values());
+}
+
+export async function findAnonymousProfileByToken(
+  roomId: string,
+  slugToken: string,
+  client?: TransactionClient,
+): Promise<RoomAnonymousProfile | null> {
+  const db = resolveClient(client);
+
+  return db.roomAnonymousProfile.findFirst({
+    where: { roomId, slugToken },
+  });
+}
+
+export async function createAnonymousProfile(
+  data: Prisma.RoomAnonymousProfileCreateArgs["data"],
+  client?: TransactionClient,
+): Promise<RoomAnonymousProfile> {
+  const db = resolveClient(client);
+
+  return db.roomAnonymousProfile.create({ data });
+}
+
+export async function updateAnonymousProfile(
+  id: string,
+  data: Prisma.RoomAnonymousProfileUpdateArgs["data"],
+  client?: TransactionClient,
+): Promise<RoomAnonymousProfile> {
+  const db = resolveClient(client);
+
+  return db.roomAnonymousProfile.update({
+    where: { id },
+    data,
+  });
+}
+
+export async function findRoomSessionByConnectionId(
+  connectionId: string,
+  client?: TransactionClient,
+): Promise<RoomSession | null> {
+  const db = resolveClient(client);
+
+  return db.roomSession.findUnique({ where: { connectionId } });
+}
+
+export async function createRoomSession(
+  data: Prisma.RoomSessionCreateArgs["data"],
+  client?: TransactionClient,
+): Promise<RoomSession> {
+  const db = resolveClient(client);
+
+  return db.roomSession.create({ data });
+}
+
+export async function updateRoomSession(
+  id: string,
+  data: Prisma.RoomSessionUpdateArgs["data"],
+  client?: TransactionClient,
+): Promise<RoomSession> {
+  const db = resolveClient(client);
+
+  return db.roomSession.update({
+    where: { id },
+    data,
+  });
+}
+
+export async function reconnectRoomSession(
+  id: string,
+  clientInfo?: Prisma.RoomSessionUpdateArgs["data"]["clientInfo"],
+  client?: TransactionClient,
+): Promise<RoomSession> {
+  return updateRoomSession(
+    id,
+    {
+      disconnectedAt: null,
+      lastPingAt: new Date(),
+      ...(clientInfo !== undefined ? { clientInfo } : {}),
+    },
+    client,
+  );
+}
+
+export async function markRoomSessionDisconnected(
+  id: string,
+  client?: TransactionClient,
+): Promise<RoomSession> {
+  return updateRoomSession(
+    id,
+    {
+      disconnectedAt: new Date(),
+      lastPingAt: new Date(),
+    },
+    client,
+  );
+}
+
+export async function updateRoomSessionHeartbeat(
+  id: string,
+  client?: TransactionClient,
+): Promise<RoomSession> {
+  return updateRoomSession(
+    id,
+    {
+      lastPingAt: new Date(),
+    },
+    client,
+  );
+}

--- a/src/lib/services/__tests__/room.test.ts
+++ b/src/lib/services/__tests__/room.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  AnonymousApprovalMode,
   MemberRole,
   Prisma,
   RoomStatus,
@@ -99,6 +100,9 @@ const baseRoom: Room = {
   allowAnonymousView: false,
   allowAnonymousEdit: false,
   allowAnonymousJoin: false,
+  requiresMemberAccount: false,
+  anonymousApprovalMode: AnonymousApprovalMode.AUTO,
+  maxParticipants: null,
   code: "",
   archivedAt: null,
   closedAt: null,

--- a/src/lib/services/__tests__/roomMember.test.ts
+++ b/src/lib/services/__tests__/roomMember.test.ts
@@ -1,0 +1,292 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AnonymousApprovalMode,
+  MemberRole,
+  RoomParticipantRole,
+  RoomParticipantSource,
+  RoomStatus,
+  type Member,
+  type Room,
+  type RoomAnonymousProfile,
+  type RoomParticipant,
+  type RoomSession,
+  type User,
+  type Workspace,
+} from "@prisma/client";
+
+vi.mock("@/lib/prisma/room", () => ({
+  findRoomById: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma/workspace", () => ({
+  findWorkspaceById: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma/member", () => ({
+  findMemberByWorkspaceAndUserId: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma/roomMember", () => ({
+  createAnonymousProfile: vi.fn(),
+  createRoomParticipant: vi.fn(),
+  createRoomSession: vi.fn(),
+  findAnonymousProfileByToken: vi.fn(),
+  findRoomParticipantByAnonymousProfileId: vi.fn(),
+  findRoomParticipantByUserId: vi.fn(),
+  findRoomSessionByConnectionId: vi.fn(),
+  listActiveParticipantIds: vi.fn(),
+  listRoomParticipantsWithSessions: vi.fn(),
+  markRoomSessionDisconnected: vi.fn(),
+  reconnectRoomSession: vi.fn(),
+  updateAnonymousProfile: vi.fn(),
+  updateRoomParticipant: vi.fn(),
+  updateRoomSessionHeartbeat: vi.fn(),
+}));
+
+import {
+  heartbeat,
+  joinRoom,
+  leaveRoom,
+  listRoomParticipants,
+  RoomMemberServiceError,
+} from "../roomMember";
+import * as roomRepo from "@/lib/prisma/room";
+import * as workspaceRepo from "@/lib/prisma/workspace";
+import * as memberRepo from "@/lib/prisma/member";
+import * as roomMemberRepo from "@/lib/prisma/roomMember";
+
+const mockedRoomRepo = vi.mocked(roomRepo);
+const mockedWorkspaceRepo = vi.mocked(workspaceRepo);
+const mockedMemberRepo = vi.mocked(memberRepo);
+const mockedRoomMemberRepo = vi.mocked(roomMemberRepo);
+
+const workspace: Workspace = {
+  id: "workspace-1",
+  name: "Команда",
+  slug: "komanda",
+  ownerId: "user-1",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const member: Member = {
+  id: "member-1",
+  workspaceId: workspace.id,
+  userId: "user-2",
+  invitedById: null,
+  role: MemberRole.EDITOR,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const room: Room = {
+  id: "room-1",
+  workspaceId: workspace.id,
+  createdById: workspace.ownerId,
+  name: "Алгоритмы",
+  slug: "algoritmy",
+  status: RoomStatus.ACTIVE,
+  allowAnonymousView: false,
+  allowAnonymousEdit: false,
+  allowAnonymousJoin: true,
+  requiresMemberAccount: false,
+  anonymousApprovalMode: AnonymousApprovalMode.AUTO,
+  maxParticipants: null,
+  code: "",
+  archivedAt: null,
+  closedAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const user: User = {
+  id: member.userId,
+  name: "Редактор",
+  email: "editor@example.com",
+  emailVerified: null,
+  image: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const baseParticipant: RoomParticipant = {
+  id: "participant-1",
+  roomId: room.id,
+  userId: member.userId,
+  anonymousProfileId: null,
+  role: RoomParticipantRole.COLLABORATOR,
+  source: RoomParticipantSource.WORKSPACE_MEMBER,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const participantWithUser = {
+  ...baseParticipant,
+  user,
+  anonymousProfile: null,
+};
+
+const activeSession: RoomSession = {
+  id: "session-1",
+  roomId: room.id,
+  participantId: baseParticipant.id,
+  connectionId: "conn-1",
+  clientInfo: null,
+  connectedAt: new Date(),
+  disconnectedAt: null,
+  lastPingAt: new Date(),
+};
+
+describe("RoomMemberService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedWorkspaceRepo.findWorkspaceById.mockResolvedValue(workspace);
+    mockedRoomRepo.findRoomById.mockResolvedValue(room);
+    mockedMemberRepo.findMemberByWorkspaceAndUserId.mockResolvedValue(member);
+    mockedRoomMemberRepo.findRoomParticipantByUserId.mockResolvedValue(null);
+    mockedRoomMemberRepo.listActiveParticipantIds.mockResolvedValue([]);
+    mockedRoomMemberRepo.createRoomParticipant.mockResolvedValue(participantWithUser);
+    mockedRoomMemberRepo.createRoomSession.mockResolvedValue(activeSession);
+    mockedRoomMemberRepo.findRoomSessionByConnectionId.mockResolvedValue(null);
+    mockedRoomMemberRepo.updateRoomParticipant.mockResolvedValue(participantWithUser);
+    mockedRoomMemberRepo.listRoomParticipantsWithSessions.mockResolvedValue([]);
+  });
+
+  it("joins room as workspace member", async () => {
+    const result = await joinRoom({
+      kind: "MEMBER",
+      roomId: room.id,
+      userId: member.userId,
+      connectionId: "conn-1",
+    });
+
+    expect(result.mode).toBe("MEMBER");
+    expect(result.participant.id).toBe(participantWithUser.id);
+    expect(result.workspaceRole).toBe(member.role);
+    expect(mockedRoomMemberRepo.createRoomParticipant).toHaveBeenCalled();
+    expect(mockedRoomMemberRepo.createRoomSession).toHaveBeenCalledWith({
+      room: { connect: { id: room.id } },
+      participant: { connect: { id: participantWithUser.id } },
+      connectionId: "conn-1",
+      clientInfo: undefined,
+    });
+  });
+
+  it("prevents joining closed room", async () => {
+    mockedRoomRepo.findRoomById.mockResolvedValue({ ...room, status: RoomStatus.CLOSED });
+
+    await expect(
+      joinRoom({
+        kind: "MEMBER",
+        roomId: room.id,
+        userId: member.userId,
+        connectionId: "conn-1",
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" } satisfies Partial<RoomMemberServiceError>);
+  });
+
+  it("reuses existing session on reconnect", async () => {
+    mockedRoomMemberRepo.findRoomParticipantByUserId.mockResolvedValue(participantWithUser);
+    mockedRoomMemberRepo.listActiveParticipantIds.mockResolvedValue([participantWithUser.id]);
+    mockedRoomMemberRepo.findRoomSessionByConnectionId.mockResolvedValue(activeSession);
+
+    const session = { ...activeSession, disconnectedAt: null };
+    mockedRoomMemberRepo.reconnectRoomSession.mockResolvedValue(session);
+
+    const result = await joinRoom({
+      kind: "MEMBER",
+      roomId: room.id,
+      userId: member.userId,
+      connectionId: activeSession.connectionId,
+    });
+
+    expect(result.session).toEqual(session);
+    expect(mockedRoomMemberRepo.reconnectRoomSession).toHaveBeenCalledWith(
+      activeSession.id,
+      undefined,
+    );
+    expect(mockedRoomMemberRepo.createRoomSession).not.toHaveBeenCalled();
+  });
+
+  it("creates anonymous participant when allowed", async () => {
+    const profile: RoomAnonymousProfile = {
+      id: "anon-1",
+      roomId: room.id,
+      displayName: "Гость",
+      slugToken: "anon-token",
+      createdAt: new Date(),
+      lastUsedAt: new Date(),
+    };
+
+    mockedRoomMemberRepo.findAnonymousProfileByToken.mockResolvedValue(null);
+    mockedRoomMemberRepo.createAnonymousProfile.mockResolvedValue(profile);
+    mockedRoomMemberRepo.updateAnonymousProfile.mockResolvedValue(profile);
+    mockedRoomMemberRepo.findRoomParticipantByAnonymousProfileId.mockResolvedValue(null);
+
+    const anonymousParticipant: RoomParticipant = {
+      id: "participant-2",
+      roomId: room.id,
+      userId: null,
+      anonymousProfileId: profile.id,
+      role: RoomParticipantRole.GUEST,
+      source: RoomParticipantSource.ANONYMOUS,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    mockedRoomMemberRepo.createRoomParticipant.mockResolvedValue({
+      ...anonymousParticipant,
+      user: null,
+      anonymousProfile: profile,
+    });
+
+    mockedRoomMemberRepo.createRoomSession.mockResolvedValue({
+      ...activeSession,
+      participantId: anonymousParticipant.id,
+    });
+
+    const result = await joinRoom({
+      kind: "ANONYMOUS",
+      roomId: room.id,
+      displayName: "  Гость  ",
+      connectionId: "conn-2",
+    });
+
+    expect(result.mode).toBe("ANONYMOUS");
+    expect(result.profile?.id).toBe(profile.id);
+    expect(mockedRoomMemberRepo.createAnonymousProfile).toHaveBeenCalled();
+  });
+
+  it("marks session as disconnected when leaving", async () => {
+    mockedRoomMemberRepo.findRoomSessionByConnectionId.mockResolvedValue(activeSession);
+    const disconnected = { ...activeSession, disconnectedAt: new Date() };
+    mockedRoomMemberRepo.markRoomSessionDisconnected.mockResolvedValue(disconnected);
+
+    const result = await leaveRoom({
+      roomId: room.id,
+      connectionId: activeSession.connectionId,
+    });
+
+    expect(result.disconnectedAt).toBeInstanceOf(Date);
+    expect(mockedRoomMemberRepo.markRoomSessionDisconnected).toHaveBeenCalledWith(activeSession.id);
+  });
+
+  it("returns null heartbeat for unknown session", async () => {
+    mockedRoomMemberRepo.findRoomSessionByConnectionId.mockResolvedValue(null);
+
+    const result = await heartbeat("missing");
+
+    expect(result).toBeNull();
+  });
+
+  it("delegates presence listing to repository", async () => {
+    mockedRoomMemberRepo.listRoomParticipantsWithSessions.mockResolvedValue([
+      { ...participantWithUser, sessions: [activeSession] },
+    ]);
+
+    const participants = await listRoomParticipants(room.id);
+
+    expect(participants).toHaveLength(1);
+    expect(mockedRoomMemberRepo.listRoomParticipantsWithSessions).toHaveBeenCalledWith(room.id);
+  });
+});

--- a/src/lib/services/roomMember.ts
+++ b/src/lib/services/roomMember.ts
@@ -1,0 +1,418 @@
+import { randomBytes } from "crypto";
+
+import {
+  AnonymousApprovalMode,
+  MemberRole,
+  RoomParticipantRole,
+  RoomParticipantSource,
+  RoomStatus,
+  type Prisma,
+  type Room,
+  type RoomAnonymousProfile,
+  type RoomSession,
+  type Workspace,
+} from "@prisma/client";
+
+import { findMemberByWorkspaceAndUserId } from "@/lib/prisma/member";
+import { findRoomById } from "@/lib/prisma/room";
+import { findWorkspaceById } from "@/lib/prisma/workspace";
+import {
+  createAnonymousProfile,
+  createRoomParticipant,
+  createRoomSession,
+  findAnonymousProfileByToken,
+  findRoomParticipantByAnonymousProfileId,
+  findRoomParticipantByUserId,
+  findRoomSessionByConnectionId,
+  listActiveParticipantIds,
+  listRoomParticipantsWithSessions,
+  markRoomSessionDisconnected,
+  reconnectRoomSession,
+  updateAnonymousProfile,
+  updateRoomParticipant,
+  updateRoomSessionHeartbeat,
+} from "@/lib/prisma/roomMember";
+import type {
+  RoomParticipantWithActiveSessions,
+  RoomParticipantWithRelations,
+} from "@/lib/prisma/roomMember";
+
+const DISPLAY_NAME_MIN_LENGTH = 2;
+const DISPLAY_NAME_MAX_LENGTH = 48;
+
+export type RoomMemberServiceErrorCode =
+  | "NOT_FOUND"
+  | "FORBIDDEN"
+  | "VALIDATION_ERROR"
+  | "LIMIT_REACHED"
+  | "CONFLICT";
+
+export class RoomMemberServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly code: RoomMemberServiceErrorCode,
+    public readonly field?: "displayName",
+  ) {
+    super(message);
+    this.name = "RoomMemberServiceError";
+  }
+}
+
+export type MemberJoinInput = {
+  kind: "MEMBER";
+  roomId: string;
+  userId: string;
+  connectionId: string;
+  clientInfo?: Prisma.JsonValue;
+};
+
+export type AnonymousJoinInput = {
+  kind: "ANONYMOUS";
+  roomId: string;
+  displayName: string;
+  connectionId: string;
+  slugToken?: string | null;
+  clientInfo?: Prisma.JsonValue;
+};
+
+export type JoinRoomInput = MemberJoinInput | AnonymousJoinInput;
+
+export type JoinRoomResult = {
+  room: Room;
+  participant: RoomParticipantWithRelations;
+  session: RoomSession;
+  mode: JoinRoomInput["kind"];
+  isNewParticipant: boolean;
+  workspaceRole?: MemberRole;
+  profile?: RoomAnonymousProfile;
+};
+
+export type LeaveRoomInput = {
+  roomId: string;
+  connectionId: string;
+};
+
+function ensureRoomAvailable(room: Room): Room {
+  if (room.status !== RoomStatus.ACTIVE) {
+    throw new RoomMemberServiceError("Комната недоступна для подключения.", "FORBIDDEN");
+  }
+
+  return room;
+}
+
+async function fetchRoomContext(roomId: string): Promise<{ room: Room; workspace: Workspace }> {
+  const room = await findRoomById(roomId);
+
+  if (!room) {
+    throw new RoomMemberServiceError("Комната не найдена.", "NOT_FOUND");
+  }
+
+  const workspace = await findWorkspaceById(room.workspaceId);
+
+  if (!workspace) {
+    throw new RoomMemberServiceError("Рабочая область не найдена.", "NOT_FOUND");
+  }
+
+  return { room: ensureRoomAvailable(room), workspace };
+}
+
+function mapMemberRoleToParticipantRole(role: MemberRole, isOwner: boolean): RoomParticipantRole {
+  if (isOwner || role === MemberRole.ADMIN) {
+    return RoomParticipantRole.HOST;
+  }
+
+  if (role === MemberRole.EDITOR) {
+    return RoomParticipantRole.COLLABORATOR;
+  }
+
+  return RoomParticipantRole.VIEWER;
+}
+
+function normalizeDisplayName(raw: string): string {
+  const value = raw.trim();
+
+  if (value.length < DISPLAY_NAME_MIN_LENGTH) {
+    throw new RoomMemberServiceError(
+      `Имя должно содержать минимум ${DISPLAY_NAME_MIN_LENGTH} символа(-ов).`,
+      "VALIDATION_ERROR",
+      "displayName",
+    );
+  }
+
+  if (value.length > DISPLAY_NAME_MAX_LENGTH) {
+    throw new RoomMemberServiceError(
+      `Имя не может превышать ${DISPLAY_NAME_MAX_LENGTH} символов.`,
+      "VALIDATION_ERROR",
+      "displayName",
+    );
+  }
+
+  return value;
+}
+
+function generateSlugToken(): string {
+  return randomBytes(12).toString("base64url");
+}
+
+async function ensureMemberAccess(
+  workspace: Workspace,
+  room: Room,
+  userId: string,
+): Promise<{ role: MemberRole; isOwner: boolean }> {
+  if (workspace.ownerId === userId) {
+    return { role: MemberRole.ADMIN, isOwner: true };
+  }
+
+  const membership = await findMemberByWorkspaceAndUserId(room.workspaceId, userId);
+
+  if (!membership) {
+    throw new RoomMemberServiceError(
+      "Вы не являетесь участником этой рабочей области.",
+      "FORBIDDEN",
+    );
+  }
+
+  return { role: membership.role, isOwner: false };
+}
+
+async function ensureAnonymousAllowed(room: Room) {
+  if (room.requiresMemberAccount) {
+    throw new RoomMemberServiceError(
+      "Анонимные подключения запрещены в этой комнате.",
+      "FORBIDDEN",
+    );
+  }
+
+  if (!room.allowAnonymousJoin) {
+    throw new RoomMemberServiceError("Комната не принимает анонимных участников.", "FORBIDDEN");
+  }
+
+  if (room.anonymousApprovalMode === AnonymousApprovalMode.MANUAL) {
+    throw new RoomMemberServiceError(
+      "Для этой комнаты требуется ручное подтверждение анонимов.",
+      "FORBIDDEN",
+    );
+  }
+}
+
+async function upsertParticipantForMember(
+  room: Room,
+  workspace: Workspace,
+  userId: string,
+  activeParticipantIds: string[],
+): Promise<{ participant: RoomParticipantWithRelations; role: MemberRole; isNew: boolean }> {
+  const { role, isOwner } = await ensureMemberAccess(workspace, room, userId);
+  const targetRole = mapMemberRoleToParticipantRole(role, isOwner);
+  const existing = await findRoomParticipantByUserId(room.id, userId);
+
+  if (!existing) {
+    if (room.maxParticipants && activeParticipantIds.length >= room.maxParticipants) {
+      throw new RoomMemberServiceError("Превышен лимит участников комнаты.", "LIMIT_REACHED");
+    }
+
+    const created = await createRoomParticipant({
+      room: { connect: { id: room.id } },
+      user: { connect: { id: userId } },
+      role: targetRole,
+      source: RoomParticipantSource.WORKSPACE_MEMBER,
+    });
+
+    return { participant: created, role, isNew: true };
+  }
+
+  if (existing.role !== targetRole) {
+    const updated = await updateRoomParticipant(existing.id, { role: targetRole });
+    return { participant: updated, role, isNew: false };
+  }
+
+  return { participant: existing, role, isNew: false };
+}
+
+async function upsertParticipantForAnonymous(
+  room: Room,
+  displayName: string,
+  slugToken: string | null | undefined,
+  activeParticipantIds: string[],
+): Promise<{
+  participant: RoomParticipantWithRelations;
+  profile: RoomAnonymousProfile;
+  isNew: boolean;
+}> {
+  await ensureAnonymousAllowed(room);
+
+  let profile = slugToken ? await findAnonymousProfileByToken(room.id, slugToken) : null;
+
+  if (!profile) {
+    if (room.maxParticipants && activeParticipantIds.length >= room.maxParticipants) {
+      throw new RoomMemberServiceError("Превышен лимит участников комнаты.", "LIMIT_REACHED");
+    }
+
+    profile = await createAnonymousProfile({
+      room: { connect: { id: room.id } },
+      displayName,
+      slugToken: slugToken ?? generateSlugToken(),
+    });
+  }
+
+  const updateData: Prisma.RoomAnonymousProfileUpdateArgs["data"] = { lastUsedAt: new Date() };
+
+  if (profile.displayName !== displayName) {
+    Object.assign(updateData, { displayName });
+  }
+
+  profile = await updateAnonymousProfile(profile.id, updateData);
+
+  let participant = await findRoomParticipantByAnonymousProfileId(room.id, profile.id);
+
+  if (!participant) {
+    if (room.maxParticipants && activeParticipantIds.length >= room.maxParticipants) {
+      throw new RoomMemberServiceError("Превышен лимит участников комнаты.", "LIMIT_REACHED");
+    }
+
+    participant = await createRoomParticipant({
+      room: { connect: { id: room.id } },
+      anonymousProfile: { connect: { id: profile.id } },
+      role: RoomParticipantRole.GUEST,
+      source: RoomParticipantSource.ANONYMOUS,
+    });
+
+    return { participant, profile, isNew: true };
+  }
+
+  return { participant, profile, isNew: false };
+}
+
+async function ensureCapacity(
+  room: Room,
+  participantId: string,
+  activeParticipantIds: string[],
+): Promise<void> {
+  if (!room.maxParticipants) {
+    return;
+  }
+
+  if (activeParticipantIds.length < room.maxParticipants) {
+    return;
+  }
+
+  if (activeParticipantIds.includes(participantId)) {
+    return;
+  }
+
+  throw new RoomMemberServiceError("Превышен лимит участников комнаты.", "LIMIT_REACHED");
+}
+
+async function ensureSessionForParticipant(
+  room: Room,
+  participant: RoomParticipantWithRelations,
+  connectionId: string,
+  clientInfo?: Prisma.JsonValue,
+): Promise<RoomSession> {
+  const existingSession = await findRoomSessionByConnectionId(connectionId);
+
+  if (existingSession) {
+    if (existingSession.participantId !== participant.id || existingSession.roomId !== room.id) {
+      throw new RoomMemberServiceError(
+        "Соединение уже используется другим участником.",
+        "CONFLICT",
+      );
+    }
+
+    return reconnectRoomSession(existingSession.id, clientInfo ?? undefined);
+  }
+
+  return createRoomSession({
+    room: { connect: { id: room.id } },
+    participant: { connect: { id: participant.id } },
+    connectionId,
+    clientInfo: clientInfo ?? undefined,
+  });
+}
+
+export async function joinRoom(input: JoinRoomInput): Promise<JoinRoomResult> {
+  const { room, workspace } = await fetchRoomContext(input.roomId);
+  const activeParticipantIds = await listActiveParticipantIds(room.id);
+
+  if (input.kind === "MEMBER") {
+    const { participant, role, isNew } = await upsertParticipantForMember(
+      room,
+      workspace,
+      input.userId,
+      activeParticipantIds,
+    );
+
+    await ensureCapacity(room, participant.id, activeParticipantIds);
+
+    const session = await ensureSessionForParticipant(
+      room,
+      participant,
+      input.connectionId,
+      input.clientInfo,
+    );
+
+    return {
+      room,
+      participant,
+      session,
+      mode: input.kind,
+      workspaceRole: role,
+      isNewParticipant: isNew,
+    };
+  }
+
+  const displayName = normalizeDisplayName(input.displayName);
+  const { participant, profile, isNew } = await upsertParticipantForAnonymous(
+    room,
+    displayName,
+    input.slugToken,
+    activeParticipantIds,
+  );
+
+  await ensureCapacity(room, participant.id, activeParticipantIds);
+
+  const session = await ensureSessionForParticipant(
+    room,
+    participant,
+    input.connectionId,
+    input.clientInfo,
+  );
+
+  return {
+    room,
+    participant,
+    session,
+    mode: input.kind,
+    profile,
+    isNewParticipant: isNew,
+  };
+}
+
+export async function leaveRoom(input: LeaveRoomInput): Promise<RoomSession> {
+  const session = await findRoomSessionByConnectionId(input.connectionId);
+
+  if (!session || session.roomId !== input.roomId) {
+    throw new RoomMemberServiceError("Сессия подключения не найдена.", "NOT_FOUND");
+  }
+
+  if (session.disconnectedAt) {
+    return session;
+  }
+
+  return markRoomSessionDisconnected(session.id);
+}
+
+export async function heartbeat(connectionId: string): Promise<RoomSession | null> {
+  const session = await findRoomSessionByConnectionId(connectionId);
+
+  if (!session || session.disconnectedAt) {
+    return null;
+  }
+
+  return updateRoomSessionHeartbeat(session.id);
+}
+
+export async function listRoomParticipants(
+  roomId: string,
+): Promise<RoomParticipantWithActiveSessions[]> {
+  return listRoomParticipantsWithSessions(roomId);
+}


### PR DESCRIPTION
## Summary
- extend the Prisma schema with presence-related models for rooms and new configuration fields
- implement the room member service with join/leave/heartbeat flows and supporting repository helpers
- cover the new service with unit tests and adjust existing room tests to the extended schema
- add a Prisma migration that materializes the room presence models and constraints

## Testing
- yarn ts
- yarn lint
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68dd8d9d45ac832c95d60a02c7e856b3