### PR TITLE
Add WebSocket-driven room presence with auto-connect UI

### DIFF
--- a/prisma/migrations/20250924000000_add_room_presence/migration.sql
+++ b/prisma/migrations/20250924000000_add_room_presence/migration.sql
@@ -1,0 +1,74 @@
+-- CreateEnum
+CREATE TYPE "AnonymousApprovalMode" AS ENUM ('AUTO', 'MANUAL');
+
+-- CreateEnum
+CREATE TYPE "RoomParticipantRole" AS ENUM ('HOST', 'COLLABORATOR', 'VIEWER', 'GUEST');
+
+-- CreateEnum
+CREATE TYPE "RoomParticipantSource" AS ENUM ('WORKSPACE_MEMBER', 'ANONYMOUS');
+
+-- AlterTable
+ALTER TABLE "Room"
+  ADD COLUMN "requiresMemberAccount" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "anonymousApprovalMode" "AnonymousApprovalMode" NOT NULL DEFAULT 'AUTO',
+  ADD COLUMN "maxParticipants" INTEGER;
+
+-- CreateTable
+CREATE TABLE "RoomAnonymousProfile" (
+    "id" TEXT NOT NULL,
+    "roomId" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "slugToken" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "RoomAnonymousProfile_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RoomParticipant" (
+    "id" TEXT NOT NULL,
+    "roomId" TEXT NOT NULL,
+    "userId" TEXT,
+    "anonymousProfileId" TEXT,
+    "role" "RoomParticipantRole" NOT NULL,
+    "source" "RoomParticipantSource" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "RoomParticipant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RoomSession" (
+    "id" TEXT NOT NULL,
+    "roomId" TEXT NOT NULL,
+    "participantId" TEXT NOT NULL,
+    "connectionId" TEXT NOT NULL,
+    "clientInfo" JSONB,
+    "connectedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "disconnectedAt" TIMESTAMP(3),
+    "lastPingAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "RoomSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RoomAnonymousProfile_slugToken_key" ON "RoomAnonymousProfile"("slugToken");
+CREATE INDEX "RoomAnonymousProfile_roomId_idx" ON "RoomAnonymousProfile"("roomId");
+
+CREATE UNIQUE INDEX "RoomParticipant_roomId_userId_key" ON "RoomParticipant"("roomId", "userId");
+CREATE UNIQUE INDEX "RoomParticipant_roomId_anonymousProfileId_key" ON "RoomParticipant"("roomId", "anonymousProfileId");
+CREATE INDEX "RoomParticipant_roomId_idx" ON "RoomParticipant"("roomId");
+
+CREATE UNIQUE INDEX "RoomSession_connectionId_key" ON "RoomSession"("connectionId");
+CREATE INDEX "RoomSession_roomId_idx" ON "RoomSession"("roomId");
+CREATE INDEX "RoomSession_participantId_idx" ON "RoomSession"("participantId");
+
+-- AddForeignKey
+ALTER TABLE "RoomAnonymousProfile" ADD CONSTRAINT "RoomAnonymousProfile_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "Room"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "RoomParticipant" ADD CONSTRAINT "RoomParticipant_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "Room"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "RoomParticipant" ADD CONSTRAINT "RoomParticipant_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "RoomParticipant" ADD CONSTRAINT "RoomParticipant_anonymousProfileId_fkey" FOREIGN KEY ("anonymousProfileId") REFERENCES "RoomAnonymousProfile"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "RoomSession" ADD CONSTRAINT "RoomSession_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "Room"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "RoomSession" ADD CONSTRAINT "RoomSession_participantId_fkey" FOREIGN KEY ("participantId") REFERENCES "RoomParticipant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
   invitedMembers Member[] @relation("MemberInvitedBy")
   templates     Template[]
   createdRooms  Room[]
+  roomParticipants RoomParticipant[]
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 }
@@ -93,6 +94,23 @@ enum RoomStatus {
   ARCHIVED
 }
 
+enum AnonymousApprovalMode {
+  AUTO
+  MANUAL
+}
+
+enum RoomParticipantRole {
+  HOST
+  COLLABORATOR
+  VIEWER
+  GUEST
+}
+
+enum RoomParticipantSource {
+  WORKSPACE_MEMBER
+  ANONYMOUS
+}
+
 model Member {
   id           String     @id @default(cuid())
   workspaceId  String
@@ -146,6 +164,9 @@ model Room {
   allowAnonymousView  Boolean     @default(false)
   allowAnonymousEdit  Boolean     @default(false)
   allowAnonymousJoin  Boolean     @default(false)
+  requiresMemberAccount Boolean   @default(false)
+  anonymousApprovalMode AnonymousApprovalMode @default(AUTO)
+  maxParticipants      Int?
   code                String      @default("")
   archivedAt          DateTime?
   closedAt            DateTime?
@@ -154,7 +175,61 @@ model Room {
 
   workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
   createdBy User      @relation(fields: [createdById], references: [id], onDelete: Cascade)
+  participants RoomParticipant[]
+  anonymousProfiles RoomAnonymousProfile[]
+  sessions RoomSession[]
 
   @@index([workspaceId])
   @@unique([workspaceId, name])
+}
+
+model RoomParticipant {
+  id                 String                  @id @default(cuid())
+  roomId             String
+  userId             String?
+  anonymousProfileId String?
+  role               RoomParticipantRole
+  source             RoomParticipantSource
+  createdAt          DateTime                @default(now())
+  updatedAt          DateTime                @updatedAt
+
+  room             Room                  @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  user             User?                 @relation(fields: [userId], references: [id], onDelete: Cascade)
+  anonymousProfile RoomAnonymousProfile? @relation(fields: [anonymousProfileId], references: [id], onDelete: Cascade)
+  sessions         RoomSession[]
+
+  @@index([roomId])
+  @@unique([roomId, userId])
+  @@unique([roomId, anonymousProfileId])
+}
+
+model RoomAnonymousProfile {
+  id         String   @id @default(cuid())
+  roomId     String
+  displayName String
+  slugToken  String   @unique
+  createdAt  DateTime @default(now())
+  lastUsedAt DateTime @default(now())
+
+  room         Room             @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  participants RoomParticipant[]
+
+  @@index([roomId])
+}
+
+model RoomSession {
+  id            String   @id @default(cuid())
+  roomId        String
+  participantId String
+  connectionId  String   @unique
+  clientInfo    Json?
+  connectedAt   DateTime @default(now())
+  disconnectedAt DateTime?
+  lastPingAt    DateTime @default(now())
+
+  room        Room            @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  participant RoomParticipant @relation(fields: [participantId], references: [id], onDelete: Cascade)
+
+  @@index([roomId])
+  @@index([participantId])
 }

--- a/src/app/api/rooms/[roomId]/ws/route.ts
+++ b/src/app/api/rooms/[roomId]/ws/route.ts
@@ -1,0 +1,17 @@
+import type { NextRequest } from "next/server";
+
+import { roomPresenceGateway } from "@/lib/websocket/roomPresenceGateway";
+
+export const runtime = "edge";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { roomId: string } },
+): Promise<Response> {
+  try {
+    return await roomPresenceGateway.handle(request, params.roomId);
+  } catch (error) {
+    console.error("Failed to establish room presence WebSocket", error);
+    return new Response("Internal Server Error", { status: 500 });
+  }
+}

--- a/src/app/rooms/[roomSlug]/anonymous-join-dialog.tsx
+++ b/src/app/rooms/[roomSlug]/anonymous-join-dialog.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Stack,
+  TextField,
+} from "@mui/material";
+
+const DISPLAY_NAME_MIN = 2;
+const DISPLAY_NAME_MAX = 48;
+
+type AnonymousJoinDialogProps = {
+  open: boolean;
+  loading?: boolean;
+  error?: string | null;
+  onClose: () => void;
+  onSubmit: (displayName: string) => Promise<void> | void;
+  initialDisplayName?: string;
+};
+
+export default function AnonymousJoinDialog({
+  open,
+  loading = false,
+  error,
+  onClose,
+  onSubmit,
+  initialDisplayName,
+}: AnonymousJoinDialogProps) {
+  const [displayName, setDisplayName] = useState("");
+  const [touched, setTouched] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setTouched(false);
+      setDisplayName(initialDisplayName ?? "");
+    } else {
+      setDisplayName("");
+    }
+  }, [initialDisplayName, open]);
+
+  const trimmedValue = displayName.trim();
+  const nameTooShort = trimmedValue.length > 0 && trimmedValue.length < DISPLAY_NAME_MIN;
+  const nameTooLong = trimmedValue.length > DISPLAY_NAME_MAX;
+  const hasLocalError = touched && (trimmedValue.length === 0 || nameTooShort || nameTooLong);
+
+  const helperText = hasLocalError
+    ? trimmedValue.length === 0
+      ? "Введите отображаемое имя"
+      : nameTooShort
+        ? `Минимум ${DISPLAY_NAME_MIN} символа`
+        : `Не более ${DISPLAY_NAME_MAX} символов`
+    : "";
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setTouched(true);
+
+    if (trimmedValue.length < DISPLAY_NAME_MIN || trimmedValue.length > DISPLAY_NAME_MAX) {
+      return;
+    }
+
+    await onSubmit(trimmedValue);
+  };
+
+  return (
+    <Dialog open={open} onClose={loading ? undefined : onClose} fullWidth maxWidth="xs">
+      <form onSubmit={handleSubmit}>
+        <DialogTitle>Введите имя</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <DialogContentText>
+              Укажите, как вы хотите отображаться в списке участников. Имя видно всем собеседникам.
+            </DialogContentText>
+            <TextField
+              autoFocus
+              label="Отображаемое имя"
+              value={displayName}
+              onChange={(event) => setDisplayName(event.target.value)}
+              onBlur={() => setTouched(true)}
+              error={hasLocalError}
+              helperText={helperText}
+              disabled={loading}
+              inputProps={{ maxLength: DISPLAY_NAME_MAX + 5 }}
+              fullWidth
+            />
+            {error ? <Alert severity="error">{error}</Alert> : null}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} disabled={loading} color="inherit">
+            Отмена
+          </Button>
+          <Button type="submit" variant="contained" disabled={loading}>
+            Продолжить
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+}

--- a/src/app/rooms/[roomSlug]/anonymous-room-client.tsx
+++ b/src/app/rooms/[roomSlug]/anonymous-room-client.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Container, Stack, Typography } from "@mui/material";
+
+import type { SerializedRoom } from "@/lib/services/room";
+import type { SerializedRoomParticipant } from "@/lib/services/roomMember";
+
+import { RoomPresenceProvider } from "./room-presence-context";
+import RoomPresencePanel from "./room-presence-panel";
+
+type AnonymousRoomClientProps = {
+  room: Pick<SerializedRoom, "id" | "name" | "allowAnonymousJoin" | "requiresMemberAccount">;
+  workspaceName: string;
+  initialParticipants: SerializedRoomParticipant[];
+};
+
+export default function AnonymousRoomClient({
+  room,
+  workspaceName,
+  initialParticipants,
+}: AnonymousRoomClientProps) {
+  return (
+    <RoomPresenceProvider
+      roomId={room.id}
+      initialParticipants={initialParticipants}
+      viewerMode="ANONYMOUS"
+    >
+      <Container maxWidth="sm" sx={{ py: { xs: 4, md: 6 } }}>
+        <Stack spacing={3}>
+          <Stack spacing={1}>
+            <Typography component="h1" variant="h4">
+              Комната «{room.name}»
+            </Typography>
+            <Typography variant="body1" color="text.secondary">
+              Вы приглашены в комнату рабочей области «{workspaceName}». Подключитесь, чтобы
+              появиться в списке участников и дождаться интервьюера.
+            </Typography>
+          </Stack>
+          <RoomPresencePanel
+            viewerUserId={null}
+            allowAnonymousJoin={room.allowAnonymousJoin}
+            requiresMemberAccount={room.requiresMemberAccount}
+          />
+        </Stack>
+      </Container>
+    </RoomPresenceProvider>
+  );
+}

--- a/src/app/rooms/[roomSlug]/presence-actions.ts
+++ b/src/app/rooms/[roomSlug]/presence-actions.ts
@@ -1,0 +1,185 @@
+"use server";
+
+import type { Prisma } from "@prisma/client";
+
+import { getCurrentUser } from "@/lib/auth";
+import {
+  joinRoom,
+  leaveRoom,
+  listRoomParticipants,
+  RoomMemberServiceError,
+  type RoomMemberServiceErrorCode,
+  serializeParticipantFromJoin,
+  serializeRoomParticipantsForClient,
+  type SerializedRoomParticipant,
+} from "@/lib/services/roomMember";
+import { publishRoomPresenceSnapshot } from "@/lib/websocket/roomPresencePublisher";
+
+export type PresenceActionErrorCode = RoomMemberServiceErrorCode | "UNKNOWN" | "UNAUTHORIZED";
+
+export type PresenceActionError = {
+  message: string;
+  code: PresenceActionErrorCode;
+  field?: "displayName";
+};
+
+function mapError(error: unknown): PresenceActionError {
+  if (error instanceof RoomMemberServiceError) {
+    return {
+      message: error.message,
+      code: error.code,
+      field: error.field,
+    };
+  }
+
+  console.error("Room presence action failed", error);
+  return {
+    message: "Не удалось выполнить действие. Попробуйте ещё раз.",
+    code: "UNKNOWN",
+  };
+}
+
+export type JoinRoomActionSuccess = {
+  participant: SerializedRoomParticipant;
+  connectionId: string;
+  mode: "MEMBER" | "ANONYMOUS";
+  slugToken?: string;
+  isNewParticipant: boolean;
+};
+
+export type JoinRoomActionResult =
+  | { ok: true; data: JoinRoomActionSuccess }
+  | { ok: false; error: PresenceActionError };
+
+export async function joinRoomAction(
+  roomId: string,
+  payload: {
+    connectionId: string;
+    displayName?: string;
+    slugToken?: string | null;
+    clientInfo?: Prisma.JsonValue;
+  },
+): Promise<JoinRoomActionResult> {
+  if (!payload.connectionId) {
+    return {
+      ok: false,
+      error: {
+        message: "Отсутствует идентификатор соединения.",
+        code: "VALIDATION_ERROR",
+      },
+    };
+  }
+
+  const user = await getCurrentUser();
+
+  try {
+    if (user) {
+      const result = await joinRoom({
+        kind: "MEMBER",
+        roomId,
+        userId: user.id,
+        connectionId: payload.connectionId,
+        clientInfo: payload.clientInfo,
+      });
+
+      schedulePresenceBroadcast(roomId);
+
+      return {
+        ok: true,
+        data: {
+          participant: serializeParticipantFromJoin(result),
+          connectionId: result.session.connectionId,
+          mode: result.mode,
+          slugToken: result.profile?.slugToken,
+          isNewParticipant: result.isNewParticipant,
+        },
+      };
+    }
+
+    const displayName = payload.displayName?.trim();
+
+    if (!displayName && !payload.slugToken) {
+      return {
+        ok: false,
+        error: {
+          message: "Введите отображаемое имя.",
+          code: "VALIDATION_ERROR",
+          field: "displayName",
+        },
+      };
+    }
+
+    const result = await joinRoom({
+      kind: "ANONYMOUS",
+      roomId,
+      connectionId: payload.connectionId,
+      displayName: displayName ?? undefined,
+      slugToken: payload.slugToken,
+      clientInfo: payload.clientInfo,
+    });
+
+    schedulePresenceBroadcast(roomId);
+
+    return {
+      ok: true,
+      data: {
+        participant: serializeParticipantFromJoin(result),
+        connectionId: result.session.connectionId,
+        mode: result.mode,
+        slugToken: result.profile?.slugToken,
+        isNewParticipant: result.isNewParticipant,
+      },
+    };
+  } catch (error) {
+    return { ok: false, error: mapError(error) };
+  }
+}
+
+export type LeaveRoomActionResult = { ok: true } | { ok: false; error: PresenceActionError };
+
+export async function leaveRoomAction(
+  roomId: string,
+  payload: { connectionId: string },
+): Promise<LeaveRoomActionResult> {
+  if (!payload.connectionId) {
+    return {
+      ok: false,
+      error: {
+        message: "Не найдено активное соединение.",
+        code: "VALIDATION_ERROR",
+      },
+    };
+  }
+
+  try {
+    await leaveRoom({ roomId, connectionId: payload.connectionId });
+    schedulePresenceBroadcast(roomId);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: mapError(error) };
+  }
+}
+
+export type FetchParticipantsResult =
+  | { ok: true; data: SerializedRoomParticipant[] }
+  | { ok: false; error: PresenceActionError };
+
+export async function fetchRoomParticipantsAction(
+  roomId: string,
+): Promise<FetchParticipantsResult> {
+  try {
+    const participants = await listRoomParticipants(roomId);
+    return {
+      ok: true,
+      data: serializeRoomParticipantsForClient(participants),
+    };
+  } catch (error) {
+    return { ok: false, error: mapError(error) };
+  }
+}
+
+function schedulePresenceBroadcast(roomId: string) {
+  publishRoomPresenceSnapshot(roomId).catch((error) => {
+    console.error("Failed to broadcast room presence", error);
+  });
+}

--- a/src/app/rooms/[roomSlug]/room-participant-list.tsx
+++ b/src/app/rooms/[roomSlug]/room-participant-list.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useMemo } from "react";
+import { Avatar, Box, Chip, List, ListItem, Stack, Typography } from "@mui/material";
+
+import type { SerializedRoomParticipant } from "@/lib/services/roomMember";
+import { RoomParticipantRole } from "@prisma/client";
+
+type RoomParticipantListProps = {
+  participants: SerializedRoomParticipant[];
+  currentParticipantId?: string | null;
+  viewerUserId?: string | null;
+};
+
+const ROLE_LABELS: Record<RoomParticipantRole, string> = {
+  [RoomParticipantRole.HOST]: "Ведущий",
+  [RoomParticipantRole.COLLABORATOR]: "Интервьюер",
+  [RoomParticipantRole.VIEWER]: "Наблюдатель",
+  [RoomParticipantRole.GUEST]: "Гость",
+};
+
+const ROLE_PRIORITY: Record<RoomParticipantRole, number> = {
+  [RoomParticipantRole.HOST]: 0,
+  [RoomParticipantRole.COLLABORATOR]: 1,
+  [RoomParticipantRole.VIEWER]: 2,
+  [RoomParticipantRole.GUEST]: 3,
+};
+
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).slice(0, 2);
+  const initials = parts.map((part) => part.charAt(0).toUpperCase()).join("");
+
+  return initials || name.charAt(0).toUpperCase() || "?";
+}
+
+function formatLastSeen(lastSeenAt: string | null, isOnline: boolean): string {
+  if (!lastSeenAt) {
+    return isOnline ? "В сети" : "Не в сети";
+  }
+
+  const date = new Date(lastSeenAt);
+  const time = new Intl.DateTimeFormat("ru-RU", {
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+
+  return isOnline ? `В сети · ${time}` : `Оффлайн · был(а) ${time}`;
+}
+
+export default function RoomParticipantList({
+  participants,
+  currentParticipantId,
+  viewerUserId,
+}: RoomParticipantListProps) {
+  const sorted = useMemo(() => {
+    return [...participants].sort((a, b) => {
+      if (a.isOnline !== b.isOnline) {
+        return a.isOnline ? -1 : 1;
+      }
+
+      const roleCompare = ROLE_PRIORITY[a.role] - ROLE_PRIORITY[b.role];
+
+      if (roleCompare !== 0) {
+        return roleCompare;
+      }
+
+      return a.displayName.localeCompare(b.displayName, "ru");
+    });
+  }, [participants]);
+
+  if (sorted.length === 0) {
+    return (
+      <Box
+        sx={{
+          border: "1px dashed",
+          borderColor: "divider",
+          borderRadius: 2,
+          py: 4,
+          textAlign: "center",
+        }}
+      >
+        <Typography variant="body2" color="text.secondary">
+          В комнате пока нет участников.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <List disablePadding sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+      {sorted.map((participant) => {
+        const isCurrent = participant.id === currentParticipantId;
+        const matchesViewerUser =
+          viewerUserId && participant.user ? participant.user.id === viewerUserId : false;
+        const isSelf = isCurrent || matchesViewerUser;
+
+        return (
+          <ListItem
+            key={participant.id}
+            disableGutters
+            sx={{
+              border: "1px solid",
+              borderColor: participant.isOnline ? "success.light" : "divider",
+              borderRadius: 2,
+              px: 2,
+              py: 1.5,
+              opacity: participant.isOnline ? 1 : 0.8,
+              bgcolor: participant.isOnline ? "success.light" : "background.paper",
+            }}
+          >
+            <Stack direction="row" spacing={2} alignItems="center" sx={{ width: "100%" }}>
+              <Avatar
+                sx={{
+                  bgcolor: participant.isAnonymous ? "warning.light" : "primary.main",
+                  color: participant.isAnonymous ? "warning.contrastText" : "primary.contrastText",
+                }}
+              >
+                {getInitials(participant.displayName)}
+              </Avatar>
+              <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                  <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                    {participant.displayName}
+                  </Typography>
+                  {isSelf ? <Chip label="Вы" color="primary" size="small" /> : null}
+                  {participant.isAnonymous ? (
+                    <Chip label="Гость" variant="outlined" size="small" />
+                  ) : null}
+                </Stack>
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  alignItems="center"
+                  flexWrap="wrap"
+                  sx={{ mt: 0.5 }}
+                >
+                  <Chip label={ROLE_LABELS[participant.role]} size="small" variant="outlined" />
+                  <Typography variant="caption" color="text.secondary">
+                    {formatLastSeen(participant.lastSeenAt, participant.isOnline)}
+                  </Typography>
+                </Stack>
+              </Box>
+              <Chip
+                label={participant.isOnline ? "В сети" : "Оффлайн"}
+                size="small"
+                color={participant.isOnline ? "success" : "default"}
+                variant={participant.isOnline ? "filled" : "outlined"}
+              />
+            </Stack>
+          </ListItem>
+        );
+      })}
+    </List>
+  );
+}

--- a/src/app/rooms/[roomSlug]/room-presence-context.tsx
+++ b/src/app/rooms/[roomSlug]/room-presence-context.tsx
@@ -1,0 +1,446 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+import type { SerializedRoomParticipant } from "@/lib/services/roomMember";
+import type {
+  RoomPresenceClientMessage,
+  RoomPresenceServerMessage,
+} from "@/lib/websocket/roomPresenceMessages";
+
+import {
+  fetchRoomParticipantsAction,
+  joinRoomAction,
+  leaveRoomAction,
+  type JoinRoomActionResult,
+  type PresenceActionError,
+} from "./presence-actions";
+
+export type ViewerPresenceMode = "MEMBER" | "ANONYMOUS";
+
+type PresenceStatus = "idle" | "connecting" | "connected" | "error";
+
+type JoinOptions = {
+  displayName?: string;
+};
+
+type RoomPresenceContextValue = {
+  participants: SerializedRoomParticipant[];
+  status: PresenceStatus;
+  error: PresenceActionError | null;
+  currentParticipantId: string | null;
+  connectionId: string | null;
+  viewerMode: ViewerPresenceMode;
+  needsAnonymousProfile: boolean;
+  joinRoom: (options?: JoinOptions) => Promise<JoinRoomActionResult>;
+  leaveRoom: () => Promise<void>;
+  renameAnonymous: (displayName: string) => Promise<JoinRoomActionResult>;
+  refresh: () => Promise<void>;
+};
+
+const RoomPresenceContext = createContext<RoomPresenceContextValue | null>(null);
+
+function generateConnectionId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return `conn_${Math.random().toString(36).slice(2)}`;
+}
+
+function upsertParticipant(
+  list: SerializedRoomParticipant[],
+  participant: SerializedRoomParticipant,
+): SerializedRoomParticipant[] {
+  const index = list.findIndex((item) => item.id === participant.id);
+
+  if (index === -1) {
+    return [...list, participant];
+  }
+
+  const updated = [...list];
+  updated[index] = participant;
+  return updated;
+}
+
+function markParticipantDisconnected(
+  list: SerializedRoomParticipant[],
+  participantId: string,
+): SerializedRoomParticipant[] {
+  return list.map((participant) => {
+    if (participant.id !== participantId) {
+      return participant;
+    }
+
+    const connectedClients = Math.max(participant.connectedClients - 1, 0);
+    return {
+      ...participant,
+      connectedClients,
+      isOnline: connectedClients > 0,
+      lastSeenAt: new Date().toISOString(),
+    };
+  });
+}
+
+type RoomPresenceProviderProps = {
+  roomId: string;
+  initialParticipants: SerializedRoomParticipant[];
+  viewerMode: ViewerPresenceMode;
+  children: ReactNode;
+};
+
+export function RoomPresenceProvider({
+  roomId,
+  initialParticipants,
+  viewerMode,
+  children,
+}: RoomPresenceProviderProps) {
+  const [participants, setParticipants] = useState(initialParticipants);
+  const [status, setStatus] = useState<PresenceStatus>("idle");
+  const [error, setError] = useState<PresenceActionError | null>(null);
+  const [currentParticipantId, setCurrentParticipantId] = useState<string | null>(null);
+  const [needsAnonymousProfile, setNeedsAnonymousProfile] = useState(viewerMode === "ANONYMOUS");
+  const [anonymousToken, setAnonymousToken] = useState<string | null>(null);
+  const connectionIdRef = useRef<string | null>(null);
+  const anonymousTokenRef = useRef<string | null>(null);
+  const socketRef = useRef<WebSocket | null>(null);
+  const heartbeatRef = useRef<number | null>(null);
+
+  const storageKey = useMemo(() => `room:${roomId}:anonymous-token`, [roomId]);
+
+  const clearHeartbeat = useCallback(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (heartbeatRef.current !== null) {
+      window.clearInterval(heartbeatRef.current);
+      heartbeatRef.current = null;
+    }
+  }, []);
+
+  const ensureConnectionId = useCallback(() => {
+    if (!connectionIdRef.current) {
+      connectionIdRef.current = generateConnectionId();
+    }
+
+    return connectionIdRef.current;
+  }, []);
+
+  useEffect(() => {
+    if (viewerMode !== "ANONYMOUS") {
+      return;
+    }
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const stored = window.localStorage.getItem(storageKey);
+
+    if (stored) {
+      anonymousTokenRef.current = stored;
+      setAnonymousToken(stored);
+      setNeedsAnonymousProfile(false);
+    }
+  }, [storageKey, viewerMode]);
+
+  const persistAnonymousToken = useCallback(
+    (token: string | undefined) => {
+      if (viewerMode !== "ANONYMOUS") {
+        return;
+      }
+
+      if (!token) {
+        return;
+      }
+
+      anonymousTokenRef.current = token;
+      setAnonymousToken(token);
+
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(storageKey, token);
+      }
+    },
+    [storageKey, viewerMode],
+  );
+
+  const clearAnonymousToken = useCallback(() => {
+    if (viewerMode !== "ANONYMOUS") {
+      return;
+    }
+
+    anonymousTokenRef.current = null;
+    setAnonymousToken(null);
+
+    if (typeof window !== "undefined") {
+      window.localStorage.removeItem(storageKey);
+    }
+  }, [storageKey, viewerMode]);
+
+  const handleServerMessage = useCallback(
+    (event: MessageEvent<string>) => {
+      try {
+        const message = JSON.parse(event.data) as RoomPresenceServerMessage;
+
+        switch (message.type) {
+          case "presence-sync":
+            setParticipants(message.participants);
+            setError(null);
+            setStatus((prev) => (prev === "connecting" ? "connected" : prev));
+            break;
+          case "session-ended":
+            setStatus("idle");
+            setCurrentParticipantId(null);
+
+            if (viewerMode === "ANONYMOUS") {
+              if (message.reason === "UNAUTHORIZED") {
+                clearAnonymousToken();
+              }
+
+              setNeedsAnonymousProfile(true);
+            }
+            break;
+          case "error":
+            setError({ message: message.message, code: "UNKNOWN" });
+            setStatus("error");
+            break;
+          default:
+            break;
+        }
+      } catch (err) {
+        console.error("Failed to parse room presence message", err);
+      }
+    },
+    [clearAnonymousToken, viewerMode],
+  );
+
+  const connectWebSocket = useCallback(
+    (connectionId: string) => {
+      if (typeof window === "undefined") {
+        return;
+      }
+
+      const existing = socketRef.current;
+
+      if (
+        existing &&
+        (existing.readyState === WebSocket.OPEN || existing.readyState === WebSocket.CONNECTING)
+      ) {
+        return;
+      }
+
+      const url = new URL(`/api/rooms/${roomId}/ws`, window.location.origin);
+      url.searchParams.set("connectionId", connectionId);
+
+      const socket = new WebSocket(url.toString());
+      socketRef.current = socket;
+
+      socket.addEventListener("open", () => {
+        setStatus("connected");
+        setError(null);
+      });
+
+      socket.addEventListener("message", handleServerMessage);
+
+      socket.addEventListener("close", () => {
+        clearHeartbeat();
+        socketRef.current = null;
+
+        if (viewerMode === "ANONYMOUS" && !anonymousTokenRef.current) {
+          setNeedsAnonymousProfile(true);
+        }
+
+        setStatus("idle");
+      });
+
+      socket.addEventListener("error", () => {
+        setStatus("error");
+      });
+
+      clearHeartbeat();
+
+      heartbeatRef.current = window.setInterval(() => {
+        if (socket.readyState === WebSocket.OPEN) {
+          const message: RoomPresenceClientMessage = { type: "heartbeat" };
+          socket.send(JSON.stringify(message));
+        }
+      }, 20000);
+    },
+    [clearHeartbeat, handleServerMessage, roomId, viewerMode],
+  );
+
+  const join = useCallback(
+    async (options?: JoinOptions): Promise<JoinRoomActionResult> => {
+      setStatus("connecting");
+      setError(null);
+
+      const connectionId = ensureConnectionId();
+      const result = await joinRoomAction(roomId, {
+        connectionId,
+        displayName: options?.displayName,
+        slugToken: anonymousTokenRef.current,
+      });
+
+      if (!result.ok) {
+        if (result.error.field === "displayName" && viewerMode === "ANONYMOUS") {
+          setNeedsAnonymousProfile(true);
+        }
+
+        setStatus(result.error.code === "VALIDATION_ERROR" ? "idle" : "error");
+        setError(result.error);
+        return result;
+      }
+
+      setParticipants((prev) => upsertParticipant(prev, result.data.participant));
+      setCurrentParticipantId(result.data.participant.id);
+      setStatus("connected");
+      persistAnonymousToken(result.data.slugToken);
+      setNeedsAnonymousProfile(false);
+
+      connectWebSocket(result.data.connectionId);
+
+      return result;
+    },
+    [connectWebSocket, ensureConnectionId, persistAnonymousToken, roomId, viewerMode],
+  );
+
+  const leave = useCallback(async () => {
+    const connectionId = connectionIdRef.current;
+
+    if (!connectionId) {
+      return;
+    }
+
+    if (socketRef.current) {
+      socketRef.current.close();
+      socketRef.current = null;
+    }
+
+    clearHeartbeat();
+
+    const result = await leaveRoomAction(roomId, { connectionId });
+
+    if (!result.ok) {
+      setError(result.error);
+      setStatus("error");
+      return;
+    }
+
+    if (currentParticipantId) {
+      setParticipants((prev) => markParticipantDisconnected(prev, currentParticipantId));
+    }
+
+    setCurrentParticipantId(null);
+    setStatus("idle");
+    connectionIdRef.current = null;
+  }, [clearHeartbeat, currentParticipantId, roomId]);
+
+  const renameAnonymous = useCallback(
+    async (displayName: string) => {
+      return join({ displayName });
+    },
+    [join],
+  );
+
+  const refresh = useCallback(async () => {
+    const result = await fetchRoomParticipantsAction(roomId);
+
+    if (!result.ok) {
+      setError(result.error);
+      setStatus("error");
+      return;
+    }
+
+    setParticipants(result.data);
+    setError(null);
+  }, [roomId]);
+
+  useEffect(() => {
+    return () => {
+      if (socketRef.current) {
+        socketRef.current.removeEventListener("message", handleServerMessage);
+        socketRef.current.close();
+        socketRef.current = null;
+      }
+
+      clearHeartbeat();
+    };
+  }, [clearHeartbeat, handleServerMessage]);
+
+  useEffect(() => {
+    if (viewerMode === "ANONYMOUS") {
+      if (status === "idle" && !anonymousTokenRef.current && !currentParticipantId) {
+        setNeedsAnonymousProfile(true);
+      }
+    } else {
+      setNeedsAnonymousProfile(false);
+    }
+  }, [currentParticipantId, status, viewerMode]);
+
+  useEffect(() => {
+    if (status !== "idle") {
+      return;
+    }
+
+    if (viewerMode === "MEMBER") {
+      void join();
+      return;
+    }
+
+    if (viewerMode === "ANONYMOUS" && anonymousTokenRef.current) {
+      void join();
+    }
+  }, [join, status, viewerMode, anonymousToken]);
+
+  const contextValue = useMemo<RoomPresenceContextValue>(
+    () => ({
+      participants,
+      status,
+      error,
+      currentParticipantId,
+      connectionId: connectionIdRef.current,
+      viewerMode,
+      needsAnonymousProfile,
+      joinRoom: join,
+      leaveRoom: leave,
+      renameAnonymous,
+      refresh,
+    }),
+    [
+      participants,
+      status,
+      error,
+      currentParticipantId,
+      viewerMode,
+      needsAnonymousProfile,
+      join,
+      leave,
+      renameAnonymous,
+      refresh,
+    ],
+  );
+
+  return (
+    <RoomPresenceContext.Provider value={contextValue}>{children}</RoomPresenceContext.Provider>
+  );
+}
+
+export function useRoomPresence(): RoomPresenceContextValue {
+  const context = useContext(RoomPresenceContext);
+
+  if (!context) {
+    throw new Error("useRoomPresence must be used within a RoomPresenceProvider");
+  }
+
+  return context;
+}

--- a/src/app/rooms/[roomSlug]/room-presence-panel.tsx
+++ b/src/app/rooms/[roomSlug]/room-presence-panel.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  Chip,
+  CircularProgress,
+  Stack,
+} from "@mui/material";
+
+import RoomParticipantList from "./room-participant-list";
+import AnonymousJoinDialog from "./anonymous-join-dialog";
+import { useRoomPresence } from "./room-presence-context";
+
+type RoomPresencePanelProps = {
+  viewerUserId?: string | null;
+  allowAnonymousJoin: boolean;
+  requiresMemberAccount: boolean;
+};
+
+export default function RoomPresencePanel({
+  viewerUserId,
+  allowAnonymousJoin,
+  requiresMemberAccount,
+}: RoomPresencePanelProps) {
+  const {
+    participants,
+    status,
+    error,
+    joinRoom,
+    refresh,
+    viewerMode,
+    currentParticipantId,
+    needsAnonymousProfile,
+  } = useRoomPresence();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [dialogMode, setDialogMode] = useState<"register" | "rename">("register");
+  const [pendingAction, setPendingAction] = useState<"join" | "rename" | "refresh" | null>(null);
+
+  const onlineCount = useMemo(
+    () => participants.filter((participant) => participant.isOnline).length,
+    [participants],
+  );
+
+  const totalCount = participants.length;
+
+  const anonymousJoinDisabledReason = useMemo(() => {
+    if (viewerMode !== "ANONYMOUS") {
+      return null;
+    }
+
+    if (requiresMemberAccount) {
+      return "Для подключения необходим аккаунт участника.";
+    }
+
+    if (!allowAnonymousJoin) {
+      return "Анонимные подключения отключены владельцем комнаты.";
+    }
+
+    return null;
+  }, [allowAnonymousJoin, requiresMemberAccount, viewerMode]);
+
+  const currentParticipant = useMemo(
+    () => participants.find((participant) => participant.id === currentParticipantId) ?? null,
+    [participants, currentParticipantId],
+  );
+
+  useEffect(() => {
+    if (viewerMode !== "ANONYMOUS") {
+      return;
+    }
+
+    if (anonymousJoinDisabledReason) {
+      setIsDialogOpen(false);
+      return;
+    }
+
+    if (needsAnonymousProfile) {
+      setDialogMode("register");
+      setIsDialogOpen(true);
+    }
+  }, [anonymousJoinDisabledReason, needsAnonymousProfile, viewerMode]);
+
+  useEffect(() => {
+    if (!needsAnonymousProfile && dialogMode === "register" && isDialogOpen) {
+      setIsDialogOpen(false);
+    }
+  }, [dialogMode, isDialogOpen, needsAnonymousProfile]);
+
+  const handleRefresh = async () => {
+    setPendingAction("refresh");
+
+    try {
+      await refresh();
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  const handleOpenRename = () => {
+    setDialogMode("rename");
+    setIsDialogOpen(true);
+  };
+
+  const handleAnonymousSubmit = async (displayName: string) => {
+    const actionType = dialogMode === "rename" ? "rename" : "join";
+    setPendingAction(actionType);
+
+    try {
+      const result = await joinRoom({ displayName });
+
+      if (result.ok) {
+        setIsDialogOpen(false);
+      }
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  const statusChip = useMemo(() => {
+    switch (status) {
+      case "connected":
+        return <Chip label="Подключено" color="success" size="small" />;
+      case "connecting":
+        return <Chip label="Подключаемся" color="info" size="small" variant="outlined" />;
+      case "error":
+        return <Chip label="Ошибка" color="error" size="small" />;
+      default:
+        return <Chip label="Ожидание" variant="outlined" size="small" />;
+    }
+  }, [status]);
+
+  const canRenameAnonymous =
+    viewerMode === "ANONYMOUS" && !anonymousJoinDisabledReason && status === "connected";
+
+  return (
+    <>
+      <Card variant="outlined">
+        <CardHeader
+          title="Участники комнаты"
+          subheader={`Онлайн: ${onlineCount} / ${totalCount}`}
+          action={
+            <Stack direction="row" spacing={1} alignItems="center">
+              <Stack direction="row" spacing={1} alignItems="center">
+                {status === "connecting" ? <CircularProgress size={16} /> : null}
+                {statusChip}
+              </Stack>
+              <Button
+                variant="outlined"
+                onClick={handleRefresh}
+                disabled={pendingAction === "refresh"}
+                startIcon={pendingAction === "refresh" ? <CircularProgress size={16} /> : null}
+              >
+                Обновить
+              </Button>
+              {canRenameAnonymous ? (
+                <Button
+                  variant="outlined"
+                  onClick={handleOpenRename}
+                  disabled={pendingAction === "rename"}
+                  startIcon={pendingAction === "rename" ? <CircularProgress size={16} /> : null}
+                >
+                  Сменить имя
+                </Button>
+              ) : null}
+            </Stack>
+          }
+        />
+        <CardContent>
+          {error ? (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {error.message}
+            </Alert>
+          ) : null}
+          {anonymousJoinDisabledReason ? (
+            <Alert severity="info" sx={{ mb: 2 }}>
+              {anonymousJoinDisabledReason}
+            </Alert>
+          ) : null}
+          <RoomParticipantList
+            participants={participants}
+            currentParticipantId={currentParticipantId}
+            viewerUserId={viewerUserId ?? null}
+          />
+        </CardContent>
+      </Card>
+      <AnonymousJoinDialog
+        open={isDialogOpen}
+        onClose={() => setIsDialogOpen(false)}
+        onSubmit={handleAnonymousSubmit}
+        loading={pendingAction === "join" || pendingAction === "rename"}
+        error={error?.message ?? null}
+        initialDisplayName={
+          dialogMode === "rename" && currentParticipant ? currentParticipant.displayName : undefined
+        }
+      />
+    </>
+  );
+}

--- a/src/app/rooms/[roomSlug]/room-settings-client.tsx
+++ b/src/app/rooms/[roomSlug]/room-settings-client.tsx
@@ -17,6 +17,7 @@ import {
 } from "@mui/material";
 
 import type { SerializedRoom } from "@/lib/services/room";
+import type { SerializedRoomParticipant } from "@/lib/services/roomMember";
 import { ROUTES } from "@/routes";
 import { useNotification } from "@/app/notification-provider";
 
@@ -31,6 +32,8 @@ import {
   ROOM_STATUS_LABELS,
 } from "@/app/workspaces/[workspaceSlug]/rooms/room-utils";
 import { useRouter } from "next/navigation";
+import { RoomPresenceProvider } from "./room-presence-context";
+import RoomPresencePanel from "./room-presence-panel";
 
 export type WorkspaceSummary = {
   id: string;
@@ -43,6 +46,8 @@ type RoomSettingsClientProps = {
   workspace: WorkspaceSummary;
   canManage: boolean;
   viewerRole: MemberRole | null;
+  viewerUserId?: string | null;
+  initialParticipants: SerializedRoomParticipant[];
 };
 
 export default function RoomSettingsClient({
@@ -50,6 +55,8 @@ export default function RoomSettingsClient({
   workspace,
   canManage,
   viewerRole,
+  viewerUserId,
+  initialParticipants,
 }: RoomSettingsClientProps) {
   const router = useRouter();
   const notify = useNotification();
@@ -239,6 +246,18 @@ export default function RoomSettingsClient({
             </Stack>
           </CardContent>
         </Card>
+
+        <RoomPresenceProvider
+          roomId={room.id}
+          initialParticipants={initialParticipants}
+          viewerMode="MEMBER"
+        >
+          <RoomPresencePanel
+            viewerUserId={viewerUserId ?? null}
+            allowAnonymousJoin={room.allowAnonymousJoin}
+            requiresMemberAccount={room.requiresMemberAccount}
+          />
+        </RoomPresenceProvider>
 
         <Card variant="outlined">
           <CardHeader title="Заметки и код" subheader="Текст отображается участникам комнаты." />

--- a/src/lib/prisma/roomMember.ts
+++ b/src/lib/prisma/roomMember.ts
@@ -1,0 +1,242 @@
+import type { Prisma, RoomAnonymousProfile, RoomSession } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+
+const baseParticipantInclude = {
+  user: true,
+  anonymousProfile: true,
+} satisfies Prisma.RoomParticipantInclude;
+
+const participantWithSessionsInclude = {
+  ...baseParticipantInclude,
+  sessions: {
+    where: { disconnectedAt: null },
+    orderBy: { connectedAt: "desc" as const },
+  },
+} satisfies Prisma.RoomParticipantInclude;
+
+const sessionWithParticipantInclude = {
+  participant: {
+    include: baseParticipantInclude,
+  },
+  room: true,
+} satisfies Prisma.RoomSessionInclude;
+
+export type RoomParticipantWithRelations = Prisma.RoomParticipantGetPayload<{
+  include: typeof baseParticipantInclude;
+}>;
+
+export type RoomParticipantWithActiveSessions = Prisma.RoomParticipantGetPayload<{
+  include: typeof participantWithSessionsInclude;
+}>;
+
+export type RoomSessionWithParticipant = Prisma.RoomSessionGetPayload<{
+  include: typeof sessionWithParticipantInclude;
+}>;
+
+type TransactionClient = Prisma.TransactionClient;
+type ClientLike = typeof prisma | TransactionClient;
+
+function resolveClient(client?: TransactionClient): ClientLike {
+  return client ?? prisma;
+}
+
+export async function findRoomParticipantByUserId(
+  roomId: string,
+  userId: string,
+  client?: TransactionClient,
+): Promise<RoomParticipantWithRelations | null> {
+  const db = resolveClient(client);
+
+  return db.roomParticipant.findFirst({
+    where: { roomId, userId },
+    include: baseParticipantInclude,
+  });
+}
+
+export async function findRoomParticipantByAnonymousProfileId(
+  roomId: string,
+  anonymousProfileId: string,
+  client?: TransactionClient,
+): Promise<RoomParticipantWithRelations | null> {
+  const db = resolveClient(client);
+
+  return db.roomParticipant.findFirst({
+    where: { roomId, anonymousProfileId },
+    include: baseParticipantInclude,
+  });
+}
+
+export async function createRoomParticipant(
+  data: Prisma.RoomParticipantCreateArgs["data"],
+  client?: TransactionClient,
+): Promise<RoomParticipantWithRelations> {
+  const db = resolveClient(client);
+
+  return db.roomParticipant.create({
+    data,
+    include: baseParticipantInclude,
+  });
+}
+
+export async function updateRoomParticipant(
+  id: string,
+  data: Prisma.RoomParticipantUpdateArgs["data"],
+  client?: TransactionClient,
+): Promise<RoomParticipantWithRelations> {
+  const db = resolveClient(client);
+
+  return db.roomParticipant.update({
+    where: { id },
+    data,
+    include: baseParticipantInclude,
+  });
+}
+
+export async function listRoomParticipantsWithSessions(
+  roomId: string,
+  client?: TransactionClient,
+): Promise<RoomParticipantWithActiveSessions[]> {
+  const db = resolveClient(client);
+
+  return db.roomParticipant.findMany({
+    where: { roomId },
+    include: participantWithSessionsInclude,
+    orderBy: [{ user: { name: "asc" } }, { createdAt: "asc" }],
+  });
+}
+
+export async function listActiveParticipantIds(
+  roomId: string,
+  client?: TransactionClient,
+): Promise<string[]> {
+  const db = resolveClient(client);
+
+  const rows = await db.roomSession.findMany({
+    where: { roomId, disconnectedAt: null },
+    select: { participantId: true },
+  });
+
+  const unique = new Set(rows.map((row) => row.participantId));
+  return Array.from(unique.values());
+}
+
+export async function findAnonymousProfileByToken(
+  roomId: string,
+  slugToken: string,
+  client?: TransactionClient,
+): Promise<RoomAnonymousProfile | null> {
+  const db = resolveClient(client);
+
+  return db.roomAnonymousProfile.findFirst({
+    where: { roomId, slugToken },
+  });
+}
+
+export async function createAnonymousProfile(
+  data: Prisma.RoomAnonymousProfileCreateArgs["data"],
+  client?: TransactionClient,
+): Promise<RoomAnonymousProfile> {
+  const db = resolveClient(client);
+
+  return db.roomAnonymousProfile.create({ data });
+}
+
+export async function updateAnonymousProfile(
+  id: string,
+  data: Prisma.RoomAnonymousProfileUpdateArgs["data"],
+  client?: TransactionClient,
+): Promise<RoomAnonymousProfile> {
+  const db = resolveClient(client);
+
+  return db.roomAnonymousProfile.update({
+    where: { id },
+    data,
+  });
+}
+
+export async function findRoomSessionByConnectionId(
+  connectionId: string,
+  client?: TransactionClient,
+): Promise<RoomSession | null> {
+  const db = resolveClient(client);
+
+  return db.roomSession.findUnique({ where: { connectionId } });
+}
+
+export async function findRoomSessionWithParticipant(
+  connectionId: string,
+  client?: TransactionClient,
+): Promise<RoomSessionWithParticipant | null> {
+  const db = resolveClient(client);
+
+  return db.roomSession.findUnique({
+    where: { connectionId },
+    include: sessionWithParticipantInclude,
+  });
+}
+
+export async function createRoomSession(
+  data: Prisma.RoomSessionCreateArgs["data"],
+  client?: TransactionClient,
+): Promise<RoomSession> {
+  const db = resolveClient(client);
+
+  return db.roomSession.create({ data });
+}
+
+export async function updateRoomSession(
+  id: string,
+  data: Prisma.RoomSessionUpdateArgs["data"],
+  client?: TransactionClient,
+): Promise<RoomSession> {
+  const db = resolveClient(client);
+
+  return db.roomSession.update({
+    where: { id },
+    data,
+  });
+}
+
+export async function reconnectRoomSession(
+  id: string,
+  clientInfo?: Prisma.RoomSessionUpdateArgs["data"]["clientInfo"],
+  client?: TransactionClient,
+): Promise<RoomSession> {
+  return updateRoomSession(
+    id,
+    {
+      disconnectedAt: null,
+      lastPingAt: new Date(),
+      ...(clientInfo !== undefined ? { clientInfo } : {}),
+    },
+    client,
+  );
+}
+
+export async function markRoomSessionDisconnected(
+  id: string,
+  client?: TransactionClient,
+): Promise<RoomSession> {
+  return updateRoomSession(
+    id,
+    {
+      disconnectedAt: new Date(),
+      lastPingAt: new Date(),
+    },
+    client,
+  );
+}
+
+export async function updateRoomSessionHeartbeat(
+  id: string,
+  client?: TransactionClient,
+): Promise<RoomSession> {
+  return updateRoomSession(
+    id,
+    {
+      lastPingAt: new Date(),
+    },
+    client,
+  );
+}

--- a/src/lib/services/__tests__/room.test.ts
+++ b/src/lib/services/__tests__/room.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  AnonymousApprovalMode,
   MemberRole,
   Prisma,
   RoomStatus,
@@ -99,6 +100,9 @@ const baseRoom: Room = {
   allowAnonymousView: false,
   allowAnonymousEdit: false,
   allowAnonymousJoin: false,
+  requiresMemberAccount: false,
+  anonymousApprovalMode: AnonymousApprovalMode.AUTO,
+  maxParticipants: null,
   code: "",
   archivedAt: null,
   closedAt: null,

--- a/src/lib/services/__tests__/roomMember.test.ts
+++ b/src/lib/services/__tests__/roomMember.test.ts
@@ -1,0 +1,347 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AnonymousApprovalMode,
+  MemberRole,
+  RoomParticipantRole,
+  RoomParticipantSource,
+  RoomStatus,
+  type Member,
+  type Room,
+  type RoomAnonymousProfile,
+  type RoomParticipant,
+  type RoomSession,
+  type User,
+  type Workspace,
+} from "@prisma/client";
+
+vi.mock("@/lib/prisma/room", () => ({
+  findRoomById: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma/workspace", () => ({
+  findWorkspaceById: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma/member", () => ({
+  findMemberByWorkspaceAndUserId: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma/roomMember", () => ({
+  createAnonymousProfile: vi.fn(),
+  createRoomParticipant: vi.fn(),
+  createRoomSession: vi.fn(),
+  findAnonymousProfileByToken: vi.fn(),
+  findRoomParticipantByAnonymousProfileId: vi.fn(),
+  findRoomParticipantByUserId: vi.fn(),
+  findRoomSessionByConnectionId: vi.fn(),
+  listActiveParticipantIds: vi.fn(),
+  listRoomParticipantsWithSessions: vi.fn(),
+  markRoomSessionDisconnected: vi.fn(),
+  reconnectRoomSession: vi.fn(),
+  updateAnonymousProfile: vi.fn(),
+  updateRoomParticipant: vi.fn(),
+  updateRoomSessionHeartbeat: vi.fn(),
+}));
+
+import {
+  heartbeat,
+  joinRoom,
+  leaveRoom,
+  listRoomParticipants,
+  RoomMemberServiceError,
+} from "../roomMember";
+import * as roomRepo from "@/lib/prisma/room";
+import * as workspaceRepo from "@/lib/prisma/workspace";
+import * as memberRepo from "@/lib/prisma/member";
+import * as roomMemberRepo from "@/lib/prisma/roomMember";
+
+const mockedRoomRepo = vi.mocked(roomRepo);
+const mockedWorkspaceRepo = vi.mocked(workspaceRepo);
+const mockedMemberRepo = vi.mocked(memberRepo);
+const mockedRoomMemberRepo = vi.mocked(roomMemberRepo);
+
+const workspace: Workspace = {
+  id: "workspace-1",
+  name: "Команда",
+  slug: "komanda",
+  ownerId: "user-1",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const member: Member = {
+  id: "member-1",
+  workspaceId: workspace.id,
+  userId: "user-2",
+  invitedById: null,
+  role: MemberRole.EDITOR,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const room: Room = {
+  id: "room-1",
+  workspaceId: workspace.id,
+  createdById: workspace.ownerId,
+  name: "Алгоритмы",
+  slug: "algoritmy",
+  status: RoomStatus.ACTIVE,
+  allowAnonymousView: false,
+  allowAnonymousEdit: false,
+  allowAnonymousJoin: true,
+  requiresMemberAccount: false,
+  anonymousApprovalMode: AnonymousApprovalMode.AUTO,
+  maxParticipants: null,
+  code: "",
+  archivedAt: null,
+  closedAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const user: User = {
+  id: member.userId,
+  name: "Редактор",
+  email: "editor@example.com",
+  emailVerified: null,
+  image: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const baseParticipant: RoomParticipant = {
+  id: "participant-1",
+  roomId: room.id,
+  userId: member.userId,
+  anonymousProfileId: null,
+  role: RoomParticipantRole.COLLABORATOR,
+  source: RoomParticipantSource.WORKSPACE_MEMBER,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const participantWithUser = {
+  ...baseParticipant,
+  user,
+  anonymousProfile: null,
+};
+
+const activeSession: RoomSession = {
+  id: "session-1",
+  roomId: room.id,
+  participantId: baseParticipant.id,
+  connectionId: "conn-1",
+  clientInfo: null,
+  connectedAt: new Date(),
+  disconnectedAt: null,
+  lastPingAt: new Date(),
+};
+
+describe("RoomMemberService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedWorkspaceRepo.findWorkspaceById.mockResolvedValue(workspace);
+    mockedRoomRepo.findRoomById.mockResolvedValue(room);
+    mockedMemberRepo.findMemberByWorkspaceAndUserId.mockResolvedValue(member);
+    mockedRoomMemberRepo.findRoomParticipantByUserId.mockResolvedValue(null);
+    mockedRoomMemberRepo.listActiveParticipantIds.mockResolvedValue([]);
+    mockedRoomMemberRepo.createRoomParticipant.mockResolvedValue(participantWithUser);
+    mockedRoomMemberRepo.createRoomSession.mockResolvedValue(activeSession);
+    mockedRoomMemberRepo.findRoomSessionByConnectionId.mockResolvedValue(null);
+    mockedRoomMemberRepo.updateRoomParticipant.mockResolvedValue(participantWithUser);
+    mockedRoomMemberRepo.listRoomParticipantsWithSessions.mockResolvedValue([]);
+  });
+
+  it("joins room as workspace member", async () => {
+    const result = await joinRoom({
+      kind: "MEMBER",
+      roomId: room.id,
+      userId: member.userId,
+      connectionId: "conn-1",
+    });
+
+    expect(result.mode).toBe("MEMBER");
+    expect(result.participant.id).toBe(participantWithUser.id);
+    expect(result.workspaceRole).toBe(member.role);
+    expect(mockedRoomMemberRepo.createRoomParticipant).toHaveBeenCalled();
+    expect(mockedRoomMemberRepo.createRoomSession).toHaveBeenCalledWith({
+      room: { connect: { id: room.id } },
+      participant: { connect: { id: participantWithUser.id } },
+      connectionId: "conn-1",
+      clientInfo: undefined,
+    });
+  });
+
+  it("prevents joining closed room", async () => {
+    mockedRoomRepo.findRoomById.mockResolvedValue({ ...room, status: RoomStatus.CLOSED });
+
+    await expect(
+      joinRoom({
+        kind: "MEMBER",
+        roomId: room.id,
+        userId: member.userId,
+        connectionId: "conn-1",
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" } satisfies Partial<RoomMemberServiceError>);
+  });
+
+  it("reuses existing session on reconnect", async () => {
+    mockedRoomMemberRepo.findRoomParticipantByUserId.mockResolvedValue(participantWithUser);
+    mockedRoomMemberRepo.listActiveParticipantIds.mockResolvedValue([participantWithUser.id]);
+    mockedRoomMemberRepo.findRoomSessionByConnectionId.mockResolvedValue(activeSession);
+
+    const session = { ...activeSession, disconnectedAt: null };
+    mockedRoomMemberRepo.reconnectRoomSession.mockResolvedValue(session);
+
+    const result = await joinRoom({
+      kind: "MEMBER",
+      roomId: room.id,
+      userId: member.userId,
+      connectionId: activeSession.connectionId,
+    });
+
+    expect(result.session).toEqual(session);
+    expect(mockedRoomMemberRepo.reconnectRoomSession).toHaveBeenCalledWith(
+      activeSession.id,
+      undefined,
+    );
+    expect(mockedRoomMemberRepo.createRoomSession).not.toHaveBeenCalled();
+  });
+
+  it("creates anonymous participant when allowed", async () => {
+    const profile: RoomAnonymousProfile = {
+      id: "anon-1",
+      roomId: room.id,
+      displayName: "Гость",
+      slugToken: "anon-token",
+      createdAt: new Date(),
+      lastUsedAt: new Date(),
+    };
+
+    mockedRoomMemberRepo.findAnonymousProfileByToken.mockResolvedValue(null);
+    mockedRoomMemberRepo.createAnonymousProfile.mockResolvedValue(profile);
+    mockedRoomMemberRepo.updateAnonymousProfile.mockResolvedValue(profile);
+    mockedRoomMemberRepo.findRoomParticipantByAnonymousProfileId.mockResolvedValue(null);
+
+    const anonymousParticipant: RoomParticipant = {
+      id: "participant-2",
+      roomId: room.id,
+      userId: null,
+      anonymousProfileId: profile.id,
+      role: RoomParticipantRole.GUEST,
+      source: RoomParticipantSource.ANONYMOUS,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    mockedRoomMemberRepo.createRoomParticipant.mockResolvedValue({
+      ...anonymousParticipant,
+      user: null,
+      anonymousProfile: profile,
+    });
+
+    mockedRoomMemberRepo.createRoomSession.mockResolvedValue({
+      ...activeSession,
+      participantId: anonymousParticipant.id,
+    });
+
+    const result = await joinRoom({
+      kind: "ANONYMOUS",
+      roomId: room.id,
+      displayName: "  Гость  ",
+      connectionId: "conn-2",
+    });
+
+    expect(result.mode).toBe("ANONYMOUS");
+    expect(result.profile?.id).toBe(profile.id);
+    expect(mockedRoomMemberRepo.createAnonymousProfile).toHaveBeenCalled();
+  });
+
+  it("reuses anonymous profile when slug token is provided", async () => {
+    const profile: RoomAnonymousProfile = {
+      id: "anon-2",
+      roomId: room.id,
+      displayName: "Гость",
+      slugToken: "existing-token",
+      createdAt: new Date(),
+      lastUsedAt: new Date(),
+    };
+
+    const anonymousParticipant: RoomParticipant = {
+      id: "participant-3",
+      roomId: room.id,
+      userId: null,
+      anonymousProfileId: profile.id,
+      role: RoomParticipantRole.GUEST,
+      source: RoomParticipantSource.ANONYMOUS,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    mockedRoomMemberRepo.findAnonymousProfileByToken.mockResolvedValue(profile);
+    mockedRoomMemberRepo.updateAnonymousProfile.mockResolvedValue(profile);
+    mockedRoomMemberRepo.findRoomParticipantByAnonymousProfileId.mockResolvedValue({
+      ...anonymousParticipant,
+      user: null,
+      anonymousProfile: profile,
+    });
+    mockedRoomMemberRepo.listActiveParticipantIds.mockResolvedValue([anonymousParticipant.id]);
+    mockedRoomMemberRepo.createRoomParticipant.mockResolvedValue({
+      ...anonymousParticipant,
+      user: null,
+      anonymousProfile: profile,
+    });
+    mockedRoomMemberRepo.createRoomSession.mockResolvedValue({
+      ...activeSession,
+      participantId: anonymousParticipant.id,
+      connectionId: "conn-3",
+    });
+
+    const result = await joinRoom({
+      kind: "ANONYMOUS",
+      roomId: room.id,
+      connectionId: "conn-3",
+      slugToken: profile.slugToken,
+    });
+
+    expect(result.profile?.id).toBe(profile.id);
+    expect(mockedRoomMemberRepo.createAnonymousProfile).not.toHaveBeenCalled();
+    expect(mockedRoomMemberRepo.updateAnonymousProfile).toHaveBeenCalledWith(
+      profile.id,
+      expect.objectContaining({ lastUsedAt: expect.any(Date) }),
+    );
+  });
+
+  it("marks session as disconnected when leaving", async () => {
+    mockedRoomMemberRepo.findRoomSessionByConnectionId.mockResolvedValue(activeSession);
+    const disconnected = { ...activeSession, disconnectedAt: new Date() };
+    mockedRoomMemberRepo.markRoomSessionDisconnected.mockResolvedValue(disconnected);
+
+    const result = await leaveRoom({
+      roomId: room.id,
+      connectionId: activeSession.connectionId,
+    });
+
+    expect(result.disconnectedAt).toBeInstanceOf(Date);
+    expect(mockedRoomMemberRepo.markRoomSessionDisconnected).toHaveBeenCalledWith(activeSession.id);
+  });
+
+  it("returns null heartbeat for unknown session", async () => {
+    mockedRoomMemberRepo.findRoomSessionByConnectionId.mockResolvedValue(null);
+
+    const result = await heartbeat("missing");
+
+    expect(result).toBeNull();
+  });
+
+  it("delegates presence listing to repository", async () => {
+    mockedRoomMemberRepo.listRoomParticipantsWithSessions.mockResolvedValue([
+      { ...participantWithUser, sessions: [activeSession] },
+    ]);
+
+    const participants = await listRoomParticipants(room.id);
+
+    expect(participants).toHaveLength(1);
+    expect(mockedRoomMemberRepo.listRoomParticipantsWithSessions).toHaveBeenCalledWith(room.id);
+  });
+});

--- a/src/lib/services/room.ts
+++ b/src/lib/services/room.ts
@@ -1,4 +1,11 @@
-import { MemberRole, Prisma, RoomStatus, type Room, type Workspace } from "@prisma/client";
+import {
+  AnonymousApprovalMode,
+  MemberRole,
+  Prisma,
+  RoomStatus,
+  type Room,
+  type Workspace,
+} from "@prisma/client";
 
 import {
   closeRoomRecord,
@@ -219,6 +226,9 @@ export type SerializedRoom = {
   allowAnonymousView: boolean;
   allowAnonymousEdit: boolean;
   allowAnonymousJoin: boolean;
+  requiresMemberAccount: boolean;
+  anonymousApprovalMode: AnonymousApprovalMode;
+  maxParticipants: number | null;
   code: string;
   archivedAt: string | null;
   closedAt: string | null;
@@ -244,6 +254,9 @@ export function serializeRoomForClient(room: Room): SerializedRoom {
     allowAnonymousView: room.allowAnonymousView,
     allowAnonymousEdit: room.allowAnonymousEdit,
     allowAnonymousJoin: room.allowAnonymousJoin,
+    requiresMemberAccount: room.requiresMemberAccount,
+    anonymousApprovalMode: room.anonymousApprovalMode,
+    maxParticipants: room.maxParticipants ?? null,
     code: room.code,
     archivedAt: room.archivedAt ? room.archivedAt.toISOString() : null,
     closedAt: room.closedAt ? room.closedAt.toISOString() : null,

--- a/src/lib/services/roomMember.ts
+++ b/src/lib/services/roomMember.ts
@@ -1,0 +1,527 @@
+import { randomBytes } from "crypto";
+
+import {
+  AnonymousApprovalMode,
+  MemberRole,
+  RoomParticipantRole,
+  RoomParticipantSource,
+  RoomStatus,
+  type Prisma,
+  type Room,
+  type RoomAnonymousProfile,
+  type RoomSession,
+  type Workspace,
+} from "@prisma/client";
+
+import { findMemberByWorkspaceAndUserId } from "@/lib/prisma/member";
+import { findRoomById } from "@/lib/prisma/room";
+import { findWorkspaceById } from "@/lib/prisma/workspace";
+import {
+  createAnonymousProfile,
+  createRoomParticipant,
+  createRoomSession,
+  findAnonymousProfileByToken,
+  findRoomParticipantByAnonymousProfileId,
+  findRoomParticipantByUserId,
+  findRoomSessionByConnectionId,
+  listActiveParticipantIds,
+  listRoomParticipantsWithSessions,
+  markRoomSessionDisconnected,
+  reconnectRoomSession,
+  updateAnonymousProfile,
+  updateRoomParticipant,
+  updateRoomSessionHeartbeat,
+} from "@/lib/prisma/roomMember";
+import type {
+  RoomParticipantWithActiveSessions,
+  RoomParticipantWithRelations,
+} from "@/lib/prisma/roomMember";
+
+const DISPLAY_NAME_MIN_LENGTH = 2;
+const DISPLAY_NAME_MAX_LENGTH = 48;
+
+export type RoomMemberServiceErrorCode =
+  | "NOT_FOUND"
+  | "FORBIDDEN"
+  | "VALIDATION_ERROR"
+  | "LIMIT_REACHED"
+  | "CONFLICT";
+
+export class RoomMemberServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly code: RoomMemberServiceErrorCode,
+    public readonly field?: "displayName",
+  ) {
+    super(message);
+    this.name = "RoomMemberServiceError";
+  }
+}
+
+export type MemberJoinInput = {
+  kind: "MEMBER";
+  roomId: string;
+  userId: string;
+  connectionId: string;
+  clientInfo?: Prisma.JsonValue;
+};
+
+export type AnonymousJoinInput = {
+  kind: "ANONYMOUS";
+  roomId: string;
+  displayName?: string;
+  connectionId: string;
+  slugToken?: string | null;
+  clientInfo?: Prisma.JsonValue;
+};
+
+export type JoinRoomInput = MemberJoinInput | AnonymousJoinInput;
+
+export type JoinRoomResult = {
+  room: Room;
+  participant: RoomParticipantWithRelations;
+  session: RoomSession;
+  mode: JoinRoomInput["kind"];
+  isNewParticipant: boolean;
+  workspaceRole?: MemberRole;
+  profile?: RoomAnonymousProfile;
+};
+
+export type LeaveRoomInput = {
+  roomId: string;
+  connectionId: string;
+};
+
+function ensureRoomAvailable(room: Room): Room {
+  if (room.status !== RoomStatus.ACTIVE) {
+    throw new RoomMemberServiceError("Комната недоступна для подключения.", "FORBIDDEN");
+  }
+
+  return room;
+}
+
+async function fetchRoomContext(roomId: string): Promise<{ room: Room; workspace: Workspace }> {
+  const room = await findRoomById(roomId);
+
+  if (!room) {
+    throw new RoomMemberServiceError("Комната не найдена.", "NOT_FOUND");
+  }
+
+  const workspace = await findWorkspaceById(room.workspaceId);
+
+  if (!workspace) {
+    throw new RoomMemberServiceError("Рабочая область не найдена.", "NOT_FOUND");
+  }
+
+  return { room: ensureRoomAvailable(room), workspace };
+}
+
+function mapMemberRoleToParticipantRole(role: MemberRole, isOwner: boolean): RoomParticipantRole {
+  if (isOwner || role === MemberRole.ADMIN) {
+    return RoomParticipantRole.HOST;
+  }
+
+  if (role === MemberRole.EDITOR) {
+    return RoomParticipantRole.COLLABORATOR;
+  }
+
+  return RoomParticipantRole.VIEWER;
+}
+
+function normalizeDisplayName(raw: string): string {
+  const value = raw.trim();
+
+  if (value.length < DISPLAY_NAME_MIN_LENGTH) {
+    throw new RoomMemberServiceError(
+      `Имя должно содержать минимум ${DISPLAY_NAME_MIN_LENGTH} символа(-ов).`,
+      "VALIDATION_ERROR",
+      "displayName",
+    );
+  }
+
+  if (value.length > DISPLAY_NAME_MAX_LENGTH) {
+    throw new RoomMemberServiceError(
+      `Имя не может превышать ${DISPLAY_NAME_MAX_LENGTH} символов.`,
+      "VALIDATION_ERROR",
+      "displayName",
+    );
+  }
+
+  return value;
+}
+
+function generateSlugToken(): string {
+  return randomBytes(12).toString("base64url");
+}
+
+async function ensureMemberAccess(
+  workspace: Workspace,
+  room: Room,
+  userId: string,
+): Promise<{ role: MemberRole; isOwner: boolean }> {
+  if (workspace.ownerId === userId) {
+    return { role: MemberRole.ADMIN, isOwner: true };
+  }
+
+  const membership = await findMemberByWorkspaceAndUserId(room.workspaceId, userId);
+
+  if (!membership) {
+    throw new RoomMemberServiceError(
+      "Вы не являетесь участником этой рабочей области.",
+      "FORBIDDEN",
+    );
+  }
+
+  return { role: membership.role, isOwner: false };
+}
+
+async function ensureAnonymousAllowed(room: Room) {
+  if (room.requiresMemberAccount) {
+    throw new RoomMemberServiceError(
+      "Анонимные подключения запрещены в этой комнате.",
+      "FORBIDDEN",
+    );
+  }
+
+  if (!room.allowAnonymousJoin) {
+    throw new RoomMemberServiceError("Комната не принимает анонимных участников.", "FORBIDDEN");
+  }
+
+  if (room.anonymousApprovalMode === AnonymousApprovalMode.MANUAL) {
+    throw new RoomMemberServiceError(
+      "Для этой комнаты требуется ручное подтверждение анонимов.",
+      "FORBIDDEN",
+    );
+  }
+}
+
+async function upsertParticipantForMember(
+  room: Room,
+  workspace: Workspace,
+  userId: string,
+  activeParticipantIds: string[],
+): Promise<{ participant: RoomParticipantWithRelations; role: MemberRole; isNew: boolean }> {
+  const { role, isOwner } = await ensureMemberAccess(workspace, room, userId);
+  const targetRole = mapMemberRoleToParticipantRole(role, isOwner);
+  const existing = await findRoomParticipantByUserId(room.id, userId);
+
+  if (!existing) {
+    if (room.maxParticipants && activeParticipantIds.length >= room.maxParticipants) {
+      throw new RoomMemberServiceError("Превышен лимит участников комнаты.", "LIMIT_REACHED");
+    }
+
+    const created = await createRoomParticipant({
+      room: { connect: { id: room.id } },
+      user: { connect: { id: userId } },
+      role: targetRole,
+      source: RoomParticipantSource.WORKSPACE_MEMBER,
+    });
+
+    return { participant: created, role, isNew: true };
+  }
+
+  if (existing.role !== targetRole) {
+    const updated = await updateRoomParticipant(existing.id, { role: targetRole });
+    return { participant: updated, role, isNew: false };
+  }
+
+  return { participant: existing, role, isNew: false };
+}
+
+async function upsertParticipantForAnonymous(
+  room: Room,
+  displayName: string | undefined,
+  slugToken: string | null | undefined,
+  activeParticipantIds: string[],
+): Promise<{
+  participant: RoomParticipantWithRelations;
+  profile: RoomAnonymousProfile;
+  isNew: boolean;
+}> {
+  await ensureAnonymousAllowed(room);
+
+  let profile = slugToken ? await findAnonymousProfileByToken(room.id, slugToken) : null;
+  let resolvedDisplayName = displayName;
+
+  if (profile && !resolvedDisplayName) {
+    resolvedDisplayName = profile.displayName;
+  }
+
+  if (!profile && !resolvedDisplayName) {
+    throw new RoomMemberServiceError(
+      "Введите отображаемое имя.",
+      "VALIDATION_ERROR",
+      "displayName",
+    );
+  }
+
+  if (!profile) {
+    if (room.maxParticipants && activeParticipantIds.length >= room.maxParticipants) {
+      throw new RoomMemberServiceError("Превышен лимит участников комнаты.", "LIMIT_REACHED");
+    }
+
+    profile = await createAnonymousProfile({
+      room: { connect: { id: room.id } },
+      displayName: resolvedDisplayName!,
+      slugToken: slugToken ?? generateSlugToken(),
+    });
+  }
+
+  const updateData: Prisma.RoomAnonymousProfileUpdateArgs["data"] = { lastUsedAt: new Date() };
+
+  if (resolvedDisplayName && profile.displayName !== resolvedDisplayName) {
+    Object.assign(updateData, { displayName: resolvedDisplayName });
+  }
+
+  profile = await updateAnonymousProfile(profile.id, updateData);
+
+  let participant = await findRoomParticipantByAnonymousProfileId(room.id, profile.id);
+
+  if (!participant) {
+    if (room.maxParticipants && activeParticipantIds.length >= room.maxParticipants) {
+      throw new RoomMemberServiceError("Превышен лимит участников комнаты.", "LIMIT_REACHED");
+    }
+
+    participant = await createRoomParticipant({
+      room: { connect: { id: room.id } },
+      anonymousProfile: { connect: { id: profile.id } },
+      role: RoomParticipantRole.GUEST,
+      source: RoomParticipantSource.ANONYMOUS,
+    });
+
+    return { participant, profile, isNew: true };
+  }
+
+  return { participant, profile, isNew: false };
+}
+
+async function ensureCapacity(
+  room: Room,
+  participantId: string,
+  activeParticipantIds: string[],
+): Promise<void> {
+  if (!room.maxParticipants) {
+    return;
+  }
+
+  if (activeParticipantIds.length < room.maxParticipants) {
+    return;
+  }
+
+  if (activeParticipantIds.includes(participantId)) {
+    return;
+  }
+
+  throw new RoomMemberServiceError("Превышен лимит участников комнаты.", "LIMIT_REACHED");
+}
+
+async function ensureSessionForParticipant(
+  room: Room,
+  participant: RoomParticipantWithRelations,
+  connectionId: string,
+  clientInfo?: Prisma.JsonValue,
+): Promise<RoomSession> {
+  const existingSession = await findRoomSessionByConnectionId(connectionId);
+
+  if (existingSession) {
+    if (existingSession.participantId !== participant.id || existingSession.roomId !== room.id) {
+      throw new RoomMemberServiceError(
+        "Соединение уже используется другим участником.",
+        "CONFLICT",
+      );
+    }
+
+    return reconnectRoomSession(existingSession.id, clientInfo ?? undefined);
+  }
+
+  return createRoomSession({
+    room: { connect: { id: room.id } },
+    participant: { connect: { id: participant.id } },
+    connectionId,
+    clientInfo: clientInfo ?? undefined,
+  });
+}
+
+export async function joinRoom(input: JoinRoomInput): Promise<JoinRoomResult> {
+  const { room, workspace } = await fetchRoomContext(input.roomId);
+  const activeParticipantIds = await listActiveParticipantIds(room.id);
+
+  if (input.kind === "MEMBER") {
+    const { participant, role, isNew } = await upsertParticipantForMember(
+      room,
+      workspace,
+      input.userId,
+      activeParticipantIds,
+    );
+
+    await ensureCapacity(room, participant.id, activeParticipantIds);
+
+    const session = await ensureSessionForParticipant(
+      room,
+      participant,
+      input.connectionId,
+      input.clientInfo,
+    );
+
+    return {
+      room,
+      participant,
+      session,
+      mode: input.kind,
+      workspaceRole: role,
+      isNewParticipant: isNew,
+    };
+  }
+
+  const displayName =
+    input.displayName !== undefined ? normalizeDisplayName(input.displayName) : undefined;
+  const { participant, profile, isNew } = await upsertParticipantForAnonymous(
+    room,
+    displayName,
+    input.slugToken,
+    activeParticipantIds,
+  );
+
+  await ensureCapacity(room, participant.id, activeParticipantIds);
+
+  const session = await ensureSessionForParticipant(
+    room,
+    participant,
+    input.connectionId,
+    input.clientInfo,
+  );
+
+  return {
+    room,
+    participant,
+    session,
+    mode: input.kind,
+    profile,
+    isNewParticipant: isNew,
+  };
+}
+
+export async function leaveRoom(input: LeaveRoomInput): Promise<RoomSession> {
+  const session = await findRoomSessionByConnectionId(input.connectionId);
+
+  if (!session || session.roomId !== input.roomId) {
+    throw new RoomMemberServiceError("Сессия подключения не найдена.", "NOT_FOUND");
+  }
+
+  if (session.disconnectedAt) {
+    return session;
+  }
+
+  return markRoomSessionDisconnected(session.id);
+}
+
+export async function heartbeat(connectionId: string): Promise<RoomSession | null> {
+  const session = await findRoomSessionByConnectionId(connectionId);
+
+  if (!session || session.disconnectedAt) {
+    return null;
+  }
+
+  return updateRoomSessionHeartbeat(session.id);
+}
+
+export async function listRoomParticipants(
+  roomId: string,
+): Promise<RoomParticipantWithActiveSessions[]> {
+  return listRoomParticipantsWithSessions(roomId);
+}
+
+export type SerializedRoomParticipant = {
+  id: string;
+  roomId: string;
+  role: RoomParticipantRole;
+  source: RoomParticipantSource;
+  displayName: string;
+  isAnonymous: boolean;
+  isOnline: boolean;
+  connectedClients: number;
+  lastSeenAt: string | null;
+  joinedAt: string;
+  updatedAt: string;
+  user?: {
+    id: string;
+    name: string | null;
+    email: string | null;
+  };
+  anonymousProfile?: {
+    id: string;
+    displayName: string;
+  };
+};
+
+function resolveParticipantDisplayName(participant: RoomParticipantWithRelations): string {
+  if (participant.user) {
+    return participant.user.name ?? participant.user.email ?? "Участник";
+  }
+
+  if (participant.anonymousProfile) {
+    return participant.anonymousProfile.displayName;
+  }
+
+  return "Неизвестный участник";
+}
+
+function resolveParticipantLastSeen(
+  participant: RoomParticipantWithRelations,
+  sessions: readonly RoomSession[],
+): Date | null {
+  if (sessions.length > 0) {
+    const [primary] = sessions;
+    return primary.lastPingAt ?? primary.connectedAt;
+  }
+
+  return participant.updatedAt;
+}
+
+export function serializeParticipantWithSessions(
+  participant: RoomParticipantWithRelations,
+  sessions: readonly RoomSession[],
+): SerializedRoomParticipant {
+  const activeSessions = sessions.filter((session) => !session.disconnectedAt);
+  const isOnline = activeSessions.length > 0;
+  const lastSeenDate = resolveParticipantLastSeen(participant, activeSessions);
+
+  return {
+    id: participant.id,
+    roomId: participant.roomId,
+    role: participant.role,
+    source: participant.source,
+    displayName: resolveParticipantDisplayName(participant),
+    isAnonymous: participant.source === RoomParticipantSource.ANONYMOUS,
+    isOnline,
+    connectedClients: activeSessions.length,
+    lastSeenAt: lastSeenDate ? lastSeenDate.toISOString() : null,
+    joinedAt: participant.createdAt.toISOString(),
+    updatedAt: participant.updatedAt.toISOString(),
+    user: participant.user
+      ? {
+          id: participant.user.id,
+          name: participant.user.name,
+          email: participant.user.email,
+        }
+      : undefined,
+    anonymousProfile: participant.anonymousProfile
+      ? {
+          id: participant.anonymousProfile.id,
+          displayName: participant.anonymousProfile.displayName,
+        }
+      : undefined,
+  };
+}
+
+export function serializeRoomParticipantsForClient(
+  participants: RoomParticipantWithActiveSessions[],
+): SerializedRoomParticipant[] {
+  return participants.map((participant) =>
+    serializeParticipantWithSessions(participant, participant.sessions),
+  );
+}
+
+export function serializeParticipantFromJoin(result: JoinRoomResult): SerializedRoomParticipant {
+  return serializeParticipantWithSessions(result.participant, [result.session]);
+}

--- a/src/lib/websocket/roomPresenceGateway.ts
+++ b/src/lib/websocket/roomPresenceGateway.ts
@@ -1,0 +1,157 @@
+import type { NextRequest } from "next/server";
+
+import {
+  findRoomSessionByConnectionId,
+  findRoomSessionWithParticipant,
+  markRoomSessionDisconnected,
+} from "@/lib/prisma/roomMember";
+import {
+  heartbeat,
+  listRoomParticipants,
+  serializeRoomParticipantsForClient,
+} from "@/lib/services/roomMember";
+
+import {
+  registerRoomConnection,
+  unregisterRoomConnection,
+  type RoomConnection,
+} from "./roomPresenceHub";
+import type { RoomPresenceClientMessage } from "./roomPresenceMessages";
+import { publishRoomPresenceSnapshot } from "./roomPresencePublisher";
+
+function createWebSocketPair(): [WebSocket, WebSocket] {
+  const globalObject = globalThis as typeof globalThis & {
+    WebSocketPair?: { new (): { 0: WebSocket; 1: WebSocket } };
+  };
+
+  if (!globalObject.WebSocketPair) {
+    throw new Error("WebSocketPair is not supported in this runtime");
+  }
+
+  const pair = new globalObject.WebSocketPair();
+  return [pair[0], pair[1]];
+}
+
+function acceptWebSocket(socket: WebSocket) {
+  const candidate = socket as WebSocket & { accept?: () => void };
+
+  if (typeof candidate.accept === "function") {
+    candidate.accept();
+  }
+}
+
+async function sendSnapshot(roomId: string, socket: WebSocket) {
+  try {
+    const participants = await listRoomParticipants(roomId);
+    const serialized = serializeRoomParticipantsForClient(participants);
+    socket.send(
+      JSON.stringify({
+        type: "presence-sync",
+        participants: serialized,
+      }),
+    );
+  } catch (error) {
+    console.error("Failed to send presence snapshot", error);
+    socket.send(
+      JSON.stringify({
+        type: "error",
+        message: "Не удалось получить состояние комнаты.",
+      }),
+    );
+  }
+}
+
+async function finalizeSession(roomId: string, connectionId: string) {
+  try {
+    const session = await findRoomSessionByConnectionId(connectionId);
+
+    if (!session || session.disconnectedAt) {
+      return;
+    }
+
+    await markRoomSessionDisconnected(session.id);
+    await publishRoomPresenceSnapshot(roomId);
+  } catch (error) {
+    console.error("Failed to finalize room session", error);
+  }
+}
+
+async function handleClientMessage(
+  roomId: string,
+  connectionId: string,
+  socket: WebSocket,
+  event: MessageEvent,
+) {
+  try {
+    const data = JSON.parse(event.data as string) as RoomPresenceClientMessage;
+
+    switch (data.type) {
+      case "heartbeat":
+        await heartbeat(connectionId);
+        break;
+      case "refresh-request":
+        await sendSnapshot(roomId, socket);
+        break;
+      default:
+        break;
+    }
+  } catch (error) {
+    console.error("Failed to process presence message", error);
+  }
+}
+
+class RoomPresenceGateway {
+  async handle(request: NextRequest, roomId: string): Promise<Response> {
+    if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+      return new Response("Expected WebSocket", { status: 400 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const connectionId = searchParams.get("connectionId");
+
+    if (!connectionId) {
+      return new Response("Missing connectionId", { status: 400 });
+    }
+
+    const session = await findRoomSessionWithParticipant(connectionId);
+
+    if (!session || session.roomId !== roomId || session.disconnectedAt) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const [clientSocket, serverSocket] = createWebSocketPair();
+
+    acceptWebSocket(serverSocket);
+
+    const roomConnection: RoomConnection = {
+      socket: serverSocket,
+      connectionId,
+    };
+
+    registerRoomConnection(roomId, roomConnection);
+
+    serverSocket.addEventListener("message", (event) => {
+      void handleClientMessage(roomId, connectionId, serverSocket, event);
+    });
+
+    serverSocket.addEventListener("close", () => {
+      unregisterRoomConnection(roomId, roomConnection);
+      void finalizeSession(roomId, connectionId);
+    });
+
+    serverSocket.addEventListener("error", () => {
+      unregisterRoomConnection(roomId, roomConnection);
+      void finalizeSession(roomId, connectionId);
+    });
+
+    await heartbeat(connectionId);
+    await sendSnapshot(roomId, serverSocket);
+
+    return new Response(null, {
+      status: 101,
+      webSocket: clientSocket,
+    } as ResponseInit & { webSocket: WebSocket });
+  }
+}
+
+export const roomPresenceGateway = new RoomPresenceGateway();

--- a/src/lib/websocket/roomPresenceHub.ts
+++ b/src/lib/websocket/roomPresenceHub.ts
@@ -1,0 +1,65 @@
+import type { RoomPresenceServerMessage } from "./roomPresenceMessages";
+
+export type RoomConnection = {
+  socket: WebSocket;
+  connectionId: string;
+};
+
+const roomConnections = new Map<string, Set<RoomConnection>>();
+
+export function registerRoomConnection(roomId: string, connection: RoomConnection): void {
+  const connections = roomConnections.get(roomId) ?? new Set<RoomConnection>();
+  connections.add(connection);
+  roomConnections.set(roomId, connections);
+}
+
+export function unregisterRoomConnection(roomId: string, connection: RoomConnection): void {
+  const connections = roomConnections.get(roomId);
+
+  if (!connections) {
+    return;
+  }
+
+  connections.delete(connection);
+
+  if (connections.size === 0) {
+    roomConnections.delete(roomId);
+  }
+}
+
+export function broadcastRoomMessage(
+  roomId: string,
+  message: RoomPresenceServerMessage,
+  options: { exclude?: WebSocket } = {},
+): void {
+  const connections = roomConnections.get(roomId);
+
+  if (!connections || connections.size === 0) {
+    return;
+  }
+
+  const payload = JSON.stringify(message);
+
+  for (const connection of Array.from(connections.values())) {
+    if (connection.socket === options.exclude) {
+      continue;
+    }
+
+    if (connection.socket.readyState !== WebSocket.OPEN) {
+      connections.delete(connection);
+      continue;
+    }
+
+    try {
+      connection.socket.send(payload);
+    } catch (error) {
+      console.error("Failed to send presence message", error);
+      connection.socket.close();
+      connections.delete(connection);
+    }
+  }
+
+  if (connections.size === 0) {
+    roomConnections.delete(roomId);
+  }
+}

--- a/src/lib/websocket/roomPresenceMessages.ts
+++ b/src/lib/websocket/roomPresenceMessages.ts
@@ -1,0 +1,17 @@
+import type { SerializedRoomParticipant } from "@/lib/services/roomMember";
+
+export type RoomPresenceServerMessage =
+  | {
+      type: "presence-sync";
+      participants: SerializedRoomParticipant[];
+    }
+  | {
+      type: "session-ended";
+      reason: "DISCONNECTED" | "UNAUTHORIZED" | "CLOSED";
+    }
+  | {
+      type: "error";
+      message: string;
+    };
+
+export type RoomPresenceClientMessage = { type: "heartbeat" } | { type: "refresh-request" };

--- a/src/lib/websocket/roomPresencePublisher.ts
+++ b/src/lib/websocket/roomPresencePublisher.ts
@@ -1,0 +1,16 @@
+import {
+  listRoomParticipants,
+  serializeRoomParticipantsForClient,
+} from "@/lib/services/roomMember";
+
+import { broadcastRoomMessage } from "./roomPresenceHub";
+
+export async function publishRoomPresenceSnapshot(roomId: string): Promise<void> {
+  const participants = await listRoomParticipants(roomId);
+  const serialized = serializeRoomParticipantsForClient(participants);
+
+  broadcastRoomMessage(roomId, {
+    type: "presence-sync",
+    participants: serialized,
+  });
+}


### PR DESCRIPTION
## Summary
- introduce a room presence WebSocket gateway, broadcaster, and API route to stream participant updates
- update server actions and room member service to reuse anonymous profiles, publish presence snapshots, and support WebSocket clients
- refresh the room presence client to auto-connect, handle realtime updates, and streamline the anonymous join dialog

## Testing
- yarn ts
- yarn lint
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68dd8d9d45ac832c95d60a02c7e856b3